### PR TITLE
Add Installation Instructions for cargo-nextest to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ $ cargo-build-sbf
 
 ## Running Tests
 
+If you haven't installed `cargo-nextest` yet, it's recommended to install it.
+You find the installation instructions [here](https://nexte.st/docs/installation/from-source/).
+
 ### Outside of SVM
 
 ```console
@@ -53,7 +56,7 @@ $ cargo nextest run
 ### Testing using the SVM environment
 
 ```console
-$ cargo-build-sbf && SBF_OUT_DIR=$(pwd)/target/sbf-solana-solana/release cargo nextest run
+$ cargo-build-sbf && SBF_OUT_DIR=$(pwd)/target/sbf-solana-solana/release cargo nextest run --all-features
 ```
 
 ## Contributing


### PR DESCRIPTION
- Add instructions for installing `cargo-nextest`.
- Add `--all-features` flag.