### PR TITLE
Vault: When calling set_admin, replace all secondary admins that were equal to the old admin to the new admin

### DIFF
--- a/integration_tests/tests/vault/set_admin.rs
+++ b/integration_tests/tests/vault/set_admin.rs
@@ -15,6 +15,9 @@ mod tests {
 
         let mut vault_program_client = fixture.vault_program_client();
 
+        let deposit_fee_bps = 99;
+        let withdrawal_fee_bps = 100;
+
         let (
             _config_admin,
             VaultRoot {
@@ -22,7 +25,7 @@ mod tests {
                 vault_admin,
             },
         ) = vault_program_client
-            .setup_config_and_vault(99, 100)
+            .setup_config_and_vault(deposit_fee_bps, withdrawal_fee_bps)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/set_admin.rs
+++ b/integration_tests/tests/vault/set_admin.rs
@@ -2,21 +2,18 @@
 mod tests {
     use jito_vault_core::config::Config;
     use jito_vault_sdk::{error::VaultError, instruction::VaultAdminRole};
+    use solana_program::pubkey::Pubkey;
     use solana_sdk::signature::{Keypair, Signer};
 
     use crate::fixtures::{
         fixture::TestBuilder,
-        vault_client::{assert_vault_error, VaultRoot},
+        vault_client::{assert_vault_error, VaultProgramClient, VaultRoot},
     };
 
-    #[tokio::test]
-    async fn test_set_admin_with_bad_admin() {
+    async fn setup() -> (VaultProgramClient, Pubkey, Keypair) {
         let fixture = TestBuilder::new().await;
 
         let mut vault_program_client = fixture.vault_program_client();
-
-        let deposit_fee_bps = 99;
-        let withdrawal_fee_bps = 100;
 
         let (
             _config_admin,
@@ -25,9 +22,16 @@ mod tests {
                 vault_admin,
             },
         ) = vault_program_client
-            .setup_config_and_vault(deposit_fee_bps, withdrawal_fee_bps)
+            .setup_config_and_vault(99, 100)
             .await
             .unwrap();
+
+        (vault_program_client, vault_pubkey, vault_admin)
+    }
+
+    #[tokio::test]
+    async fn test_set_admin_with_bad_admin() {
+        let (mut vault_program_client, vault_pubkey, vault_admin) = setup().await;
 
         let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
         let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();
@@ -50,23 +54,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_admin() {
-        let fixture = TestBuilder::new().await;
+        let (mut vault_program_client, vault_pubkey, vault_admin) = setup().await;
 
-        let mut vault_program_client = fixture.vault_program_client();
+        let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
+        let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();
 
-        let deposit_fee_bps = 99;
-        let withdrawal_fee_bps = 100;
+        assert_eq!(vault.admin, vault_admin.pubkey());
 
-        let (
-            _config_admin,
-            VaultRoot {
-                vault_pubkey,
-                vault_admin,
-            },
-        ) = vault_program_client
-            .setup_config_and_vault(deposit_fee_bps, withdrawal_fee_bps)
+        let new_admin = Keypair::new();
+        vault_program_client
+            .set_admin(&config_pubkey, &vault_pubkey, &vault_admin, &new_admin)
             .await
             .unwrap();
+
+        let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();
+
+        assert_eq!(vault.admin, new_admin.pubkey());
+    }
+
+    #[tokio::test]
+    async fn test_update_secondary_admin() {
+        let (mut vault_program_client, vault_pubkey, vault_admin) = setup().await;
 
         let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
         let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();

--- a/integration_tests/tests/vault/set_admin.rs
+++ b/integration_tests/tests/vault/set_admin.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use jito_vault_core::config::Config;
-    use jito_vault_sdk::error::VaultError;
+    use jito_vault_sdk::{error::VaultError, instruction::VaultAdminRole};
     use solana_sdk::signature::{Keypair, Signer};
 
     use crate::fixtures::{
@@ -74,6 +74,23 @@ mod tests {
         assert_eq!(vault.admin, vault_admin.pubkey());
 
         let new_admin = Keypair::new();
+        {
+            // Mint Burn
+            let new_admin = new_admin.pubkey();
+            vault_program_client
+                .set_secondary_admin(
+                    &config_pubkey,
+                    &vault_pubkey,
+                    &vault_admin,
+                    &new_admin,
+                    VaultAdminRole::MintBurnAdmin,
+                )
+                .await
+                .unwrap();
+
+            let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();
+            assert_eq!(vault.mint_burn_admin, new_admin);
+        }
         vault_program_client
             .set_admin(&config_pubkey, &vault_pubkey, &vault_admin, &new_admin)
             .await
@@ -82,5 +99,15 @@ mod tests {
         let vault = vault_program_client.get_vault(&vault_pubkey).await.unwrap();
 
         assert_eq!(vault.admin, new_admin.pubkey());
+
+        assert_eq!(vault.delegation_admin, new_admin.pubkey());
+        assert_eq!(vault.operator_admin, new_admin.pubkey());
+        assert_eq!(vault.ncn_admin, new_admin.pubkey());
+        assert_eq!(vault.slasher_admin, new_admin.pubkey());
+        assert_eq!(vault.capacity_admin, new_admin.pubkey());
+        assert_eq!(vault.fee_wallet, new_admin.pubkey());
+        assert_eq!(vault.mint_burn_admin, new_admin.pubkey());
+        assert_eq!(vault.withdraw_admin, new_admin.pubkey());
+        assert_eq!(vault.fee_admin, new_admin.pubkey());
     }
 }

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -135,6 +135,54 @@ impl Vault {
         }
     }
 
+    /// Replace all secondary admins that were equal to the old admin to the new admin
+    pub fn update_secondary_admin(&mut self, old_admin: &Pubkey, new_admin: &Pubkey) {
+        if self.delegation_admin.eq(old_admin) {
+            self.delegation_admin = *new_admin;
+            msg!("Delegation admin set to {:?}", new_admin);
+        }
+
+        if self.operator_admin.eq(old_admin) {
+            self.operator_admin = *new_admin;
+            msg!("Operator admin set to {:?}", new_admin);
+        }
+
+        if self.ncn_admin.eq(old_admin) {
+            self.ncn_admin = *new_admin;
+            msg!("Ncn admin set to {:?}", new_admin);
+        }
+
+        if self.slasher_admin.eq(old_admin) {
+            self.slasher_admin = *new_admin;
+            msg!("Slasher admin set to {:?}", new_admin);
+        }
+
+        if self.capacity_admin.eq(old_admin) {
+            self.capacity_admin = *new_admin;
+            msg!("Capacity admin set to {:?}", new_admin);
+        }
+
+        if self.fee_wallet.eq(old_admin) {
+            self.fee_wallet = *new_admin;
+            msg!("Fee wallet set to {:?}", new_admin);
+        }
+
+        if self.mint_burn_admin.eq(old_admin) {
+            self.mint_burn_admin = *new_admin;
+            msg!("Mint burn admin set to {:?}", new_admin);
+        }
+
+        if self.withdraw_admin.eq(old_admin) {
+            self.withdraw_admin = *new_admin;
+            msg!("Withdraw admin set to {:?}", new_admin);
+        }
+
+        if self.fee_admin.eq(old_admin) {
+            self.fee_admin = *new_admin;
+            msg!("Fee admin set to {:?}", new_admin);
+        }
+    }
+
     // ------------------------------------------
     // Asset accounting and tracking
     // ------------------------------------------

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -291,6 +291,45 @@ mod tests {
     use crate::vault::Vault;
 
     #[test]
+    fn test_update_secondary_admin_ok() {
+        let old_admin = Pubkey::new_unique();
+        let mut vault = Vault::new(
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            old_admin,
+            0,
+            Pubkey::new_unique(),
+            0,
+            0,
+            0,
+        );
+        vault.mint_burn_admin = old_admin;
+
+        assert_eq!(vault.delegation_admin, old_admin);
+        assert_eq!(vault.operator_admin, old_admin);
+        assert_eq!(vault.ncn_admin, old_admin);
+        assert_eq!(vault.slasher_admin, old_admin);
+        assert_eq!(vault.capacity_admin, old_admin);
+        assert_eq!(vault.fee_wallet, old_admin);
+        assert_eq!(vault.mint_burn_admin, old_admin);
+        assert_eq!(vault.withdraw_admin, old_admin);
+        assert_eq!(vault.fee_admin, old_admin);
+
+        let new_admin = Pubkey::new_unique();
+        vault.update_secondary_admin(&old_admin, &new_admin);
+
+        assert_eq!(vault.delegation_admin, new_admin);
+        assert_eq!(vault.operator_admin, new_admin);
+        assert_eq!(vault.ncn_admin, new_admin);
+        assert_eq!(vault.slasher_admin, new_admin);
+        assert_eq!(vault.capacity_admin, new_admin);
+        assert_eq!(vault.fee_wallet, new_admin);
+        assert_eq!(vault.mint_burn_admin, new_admin);
+        assert_eq!(vault.withdraw_admin, new_admin);
+        assert_eq!(vault.fee_admin, new_admin);
+    }
+
+    #[test]
     fn test_deposit_ratio_simple_ok() {
         let vault = Vault::new(
             Pubkey::new_unique(),

--- a/vault_program/src/set_admin.rs
+++ b/vault_program/src/set_admin.rs
@@ -27,7 +27,9 @@ pub fn process_set_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
         msg!("Invalid admin for vault");
         return Err(VaultError::VaultAdminInvalid.into());
     }
+
     vault.admin = *new_admin.key;
+
     vault.update_secondary_admin(old_admin.key, new_admin.key);
 
     Ok(())

--- a/vault_program/src/set_admin.rs
+++ b/vault_program/src/set_admin.rs
@@ -28,6 +28,7 @@ pub fn process_set_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
         return Err(VaultError::VaultAdminInvalid.into());
     }
     vault.admin = *new_admin.key;
+    vault.update_secondary_admin(old_admin.key, new_admin.key);
 
     Ok(())
 }


### PR DESCRIPTION
#### Motivation
- Closes #43 

#### Solution
- Modify `set_admin` instruction