### PR TITLE
Add greedy withdrawal allocation

### DIFF
--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -14,7 +14,7 @@ use jito_vault_core::{
 use jito_vault_sdk::{
     error::VaultError,
     inline_mpl_token_metadata,
-    instruction::VaultAdminRole,
+    instruction::{VaultAdminRole, WithdrawalAllocationMethod},
     sdk::{
         add_delegation, cooldown_delegation, initialize_config, initialize_vault,
         warmup_vault_ncn_slasher_ticket, warmup_vault_ncn_ticket,
@@ -877,7 +877,6 @@ impl VaultProgramClient {
         vault_root: &VaultRoot,
         operator: &Pubkey,
         amount: u64,
-        for_withdrawal: bool,
     ) -> TestResult<()> {
         self.cooldown_delegation(
             &Config::find_program_address(&jito_vault_program::id()).0,
@@ -891,7 +890,6 @@ impl VaultProgramClient {
             .0,
             &vault_root.vault_admin,
             amount,
-            for_withdrawal,
         )
         .await
     }
@@ -904,7 +902,6 @@ impl VaultProgramClient {
         vault_operator_delegation: &Pubkey,
         admin: &Keypair,
         amount: u64,
-        for_withdrawal: bool,
     ) -> TestResult<()> {
         let blockhash = self.banks_client.get_latest_blockhash().await?;
         self._process_transaction(&Transaction::new_signed_with_payer(
@@ -916,7 +913,6 @@ impl VaultProgramClient {
                 vault_operator_delegation,
                 &admin.pubkey(),
                 amount,
-                for_withdrawal,
             )],
             Some(&self.payer.pubkey()),
             &[&self.payer, admin],
@@ -935,8 +931,6 @@ impl VaultProgramClient {
         let config = self
             .get_config(&Config::find_program_address(&jito_vault_program::id()).0)
             .await?;
-
-        self.update_vault_balance(&vault_pubkey).await?;
 
         let vault_update_state_tracker = VaultUpdateStateTracker::find_program_address(
             &jito_vault_program::id(),
@@ -968,6 +962,8 @@ impl VaultProgramClient {
             slot / config.epoch_length,
         )
         .await?;
+
+        self.update_vault_balance(&vault_pubkey).await?;
 
         Ok(())
     }
@@ -1061,6 +1057,7 @@ impl VaultProgramClient {
                 vault_pubkey,
                 vault_update_state_tracker,
                 &self.payer.pubkey(),
+                WithdrawalAllocationMethod::Greedy,
             )],
             Some(&self.payer.pubkey()),
             &[&self.payer],

--- a/integration_tests/tests/vault/cooldown_delegation.rs
+++ b/integration_tests/tests/vault/cooldown_delegation.rs
@@ -36,7 +36,6 @@ mod tests {
                 .0,
                 &Keypair::new(),
                 1,
-                true,
             )
             .await;
         assert_vault_error(result, VaultError::VaultDelegationAdminInvalid);
@@ -72,12 +71,7 @@ mod tests {
             .unwrap();
 
         let result = vault_program_client
-            .do_cooldown_delegation(
-                &vault_root,
-                &operator_roots[0].operator_pubkey,
-                50_001,
-                false,
-            )
+            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 50_001)
             .await;
         assert_vault_error(result, VaultError::VaultSecurityUnderflow);
     }
@@ -122,7 +116,7 @@ mod tests {
             .unwrap();
 
         let result = vault_program_client
-            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 1, false)
+            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 1)
             .await;
         assert_vault_error(result, VaultError::VaultUpdateNeeded);
     }
@@ -156,12 +150,7 @@ mod tests {
             .await
             .unwrap();
         vault_program_client
-            .do_cooldown_delegation(
-                &vault_root,
-                &operator_roots[0].operator_pubkey,
-                50_000,
-                true,
-            )
+            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 50_000)
             .await
             .unwrap();
 
@@ -171,7 +160,7 @@ mod tests {
             .unwrap();
         assert_eq!(vault.delegation_state.total_security().unwrap(), 100_000);
         assert_eq!(vault.delegation_state.staked_amount, 50_000);
-        assert_eq!(vault.delegation_state.enqueued_for_withdraw_amount, 50_000);
+        assert_eq!(vault.delegation_state.enqueued_for_cooldown_amount, 50_000);
 
         let vault_operator_delegation = vault_program_client
             .get_vault_operator_delegation(
@@ -194,7 +183,7 @@ mod tests {
         assert_eq!(
             vault_operator_delegation
                 .delegation_state
-                .enqueued_for_withdraw_amount,
+                .enqueued_for_cooldown_amount,
             50_000
         );
     }
@@ -228,12 +217,7 @@ mod tests {
             .await
             .unwrap();
         vault_program_client
-            .do_cooldown_delegation(
-                &vault_root,
-                &operator_roots[0].operator_pubkey,
-                50_000,
-                false,
-            )
+            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 50_000)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/crank_vault_update_state_tracker.rs
+++ b/integration_tests/tests/vault/crank_vault_update_state_tracker.rs
@@ -186,8 +186,6 @@ mod tests {
                 staked_amount: 50_000,
                 enqueued_for_cooldown_amount: 0,
                 cooling_down_amount: 0,
-                enqueued_for_withdraw_amount: 0,
-                cooling_down_for_withdraw_amount: 0,
             }
         );
 
@@ -209,8 +207,6 @@ mod tests {
                 staked_amount: 100_000,
                 enqueued_for_cooldown_amount: 0,
                 cooling_down_amount: 0,
-                enqueued_for_withdraw_amount: 0,
-                cooling_down_for_withdraw_amount: 0,
             }
         );
     }
@@ -461,12 +457,7 @@ mod tests {
             .await
             .unwrap();
         vault_program_client
-            .do_cooldown_delegation(
-                &vault_root,
-                &operator_roots[0].operator_pubkey,
-                25_000,
-                true,
-            )
+            .do_cooldown_delegation(&vault_root, &operator_roots[0].operator_pubkey, 25_000)
             .await
             .unwrap();
         vault_program_client
@@ -474,12 +465,7 @@ mod tests {
             .await
             .unwrap();
         vault_program_client
-            .do_cooldown_delegation(
-                &vault_root,
-                &operator_roots[1].operator_pubkey,
-                25_000,
-                true,
-            )
+            .do_cooldown_delegation(&vault_root, &operator_roots[1].operator_pubkey, 25_000)
             .await
             .unwrap();
 
@@ -560,8 +546,6 @@ mod tests {
                 staked_amount: 25_000,
                 enqueued_for_cooldown_amount: 0,
                 cooling_down_amount: 0,
-                enqueued_for_withdraw_amount: 0,
-                cooling_down_for_withdraw_amount: 0,
             }
         );
 
@@ -584,8 +568,6 @@ mod tests {
                 staked_amount: 50_000,
                 enqueued_for_cooldown_amount: 0,
                 cooling_down_amount: 0,
-                enqueued_for_withdraw_amount: 0,
-                cooling_down_for_withdraw_amount: 0,
             }
         );
     }

--- a/vault_core/src/delegation_state.rs
+++ b/vault_core/src/delegation_state.rs
@@ -16,16 +16,6 @@ pub struct DelegationState {
     /// Any stake that was deactivated in the previous epoch,
     /// to be available for re-delegation in the current epoch + 1
     pub cooling_down_amount: u64,
-
-    /// Any stake that was enqueued for withdraw in the current epoch.
-    /// These funds are earmarked for withdrawal and are in the last bucket of slashed
-    /// assets.
-    pub enqueued_for_withdraw_amount: u64,
-
-    /// Any stake that was enqueued for withdraw in the previous epoch.
-    /// These funds are earmarked for withdrawal and are in the last bucket of slashed
-    /// assets.
-    pub cooling_down_for_withdraw_amount: u64,
 }
 
 impl DelegationState {
@@ -41,14 +31,6 @@ impl DelegationState {
         self.cooling_down_amount = self
             .cooling_down_amount
             .checked_sub(other.cooling_down_amount)
-            .ok_or(VaultError::VaultSecurityUnderflow)?;
-        self.enqueued_for_withdraw_amount = self
-            .enqueued_for_withdraw_amount
-            .checked_sub(other.enqueued_for_withdraw_amount)
-            .ok_or(VaultError::VaultSecurityUnderflow)?;
-        self.cooling_down_for_withdraw_amount = self
-            .cooling_down_for_withdraw_amount
-            .checked_sub(other.cooling_down_for_withdraw_amount)
             .ok_or(VaultError::VaultSecurityUnderflow)?;
         Ok(())
     }
@@ -67,14 +49,6 @@ impl DelegationState {
             .cooling_down_amount
             .checked_add(other.cooling_down_amount)
             .ok_or(VaultError::VaultSecurityOverflow)?;
-        self.enqueued_for_withdraw_amount = self
-            .enqueued_for_withdraw_amount
-            .checked_add(other.enqueued_for_withdraw_amount)
-            .ok_or(VaultError::VaultSecurityOverflow)?;
-        self.cooling_down_for_withdraw_amount = self
-            .cooling_down_for_withdraw_amount
-            .checked_add(other.cooling_down_for_withdraw_amount)
-            .ok_or(VaultError::VaultSecurityOverflow)?;
         Ok(())
     }
 
@@ -85,17 +59,6 @@ impl DelegationState {
         self.staked_amount
             .checked_add(self.enqueued_for_cooldown_amount)
             .and_then(|x| x.checked_add(self.cooling_down_amount))
-            .and_then(|x| x.checked_add(self.enqueued_for_withdraw_amount))
-            .and_then(|x| x.checked_add(self.cooling_down_for_withdraw_amount))
-            .ok_or(VaultError::VaultSecurityOverflow)
-    }
-
-    /// Returns the amount of withdrawable security, which is the sum of the amount actively staked,
-    /// the amount enqueued for cooldown, and the cooling down amount.
-    pub fn withdrawable_security(&self) -> Result<u64, VaultError> {
-        self.staked_amount
-            .checked_add(self.enqueued_for_cooldown_amount)
-            .and_then(|x| x.checked_add(self.cooling_down_amount))
             .ok_or(VaultError::VaultSecurityOverflow)
     }
 
@@ -103,8 +66,6 @@ impl DelegationState {
     pub fn update(&mut self) {
         self.cooling_down_amount = self.enqueued_for_cooldown_amount;
         self.enqueued_for_cooldown_amount = 0;
-        self.cooling_down_for_withdraw_amount = self.enqueued_for_withdraw_amount;
-        self.enqueued_for_withdraw_amount = 0;
     }
 
     /// Slashes the operator delegation by the given amount.
@@ -113,13 +74,6 @@ impl DelegationState {
     /// 1. Staked amount
     /// 2. Enqueued for cooldown amount
     /// 3. Cooling down amount
-    /// 4. Enqueued for withdraw amount
-    /// 5. Cooling down for withdraw amount
-    ///
-    /// The reason for this is that withdrawals are the most important to ensure that the funds are
-    /// available for withdrawal when a user's ticket matures. If any withdrawal funds are slashed,
-    /// the vault delegation manager needs to move funds around to ensure that the funds are available
-    /// for withdrawal.
     ///
     /// # Arguments
     /// * `slash_amount` - The amount to slash
@@ -158,8 +112,6 @@ impl DelegationState {
         apply_slash(&mut self.staked_amount)?;
         apply_slash(&mut self.enqueued_for_cooldown_amount)?;
         apply_slash(&mut self.cooling_down_amount)?;
-        apply_slash(&mut self.enqueued_for_withdraw_amount)?;
-        apply_slash(&mut self.cooling_down_for_withdraw_amount)?;
 
         // Ensure we've slashed the exact amount requested
         if remaining_slash > 0 {
@@ -185,75 +137,6 @@ impl DelegationState {
         Ok(())
     }
 
-    /// Un-delegates assets for withdraw from the operator
-    ///
-    /// Opts to pull from buckets in the following order for speed of withdrawal, taking
-    /// care to not break the invariant of cooling down assets:
-    /// 1. cooling_down_amount -> cooling_down_for_withdraw_amount (moving assets laterally)
-    /// 2. enqueued_for_cooldown_amount -> enqueued_for_withdraw_amount (moving assets laterally)
-    /// 3. staked_amount -> enqueued_for_withdraw_amount (cooling down)
-    pub fn cooldown_for_withdrawal(&mut self, amount: u64) -> Result<(), VaultError> {
-        if amount > self.withdrawable_security()? {
-            msg!("Attempting to withdraw too much from the vault");
-            return Err(VaultError::VaultSecurityUnderflow);
-        }
-
-        let mut remaining_amount = amount;
-
-        // cooling_down_amount -> cooling_down_for_withdraw_amount (moving assets laterally)
-        if self.cooling_down_amount > 0 {
-            let pull_amount = min(self.cooling_down_amount, remaining_amount);
-            self.cooling_down_amount = self
-                .cooling_down_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-            self.cooling_down_for_withdraw_amount = self
-                .cooling_down_for_withdraw_amount
-                .checked_add(pull_amount)
-                .ok_or(VaultError::VaultSecurityOverflow)?;
-            remaining_amount = remaining_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-        }
-        // enqueued_for_cooldown_amount -> enqueued_for_withdraw_amount (moving assets laterally)
-        if self.enqueued_for_cooldown_amount > 0 && remaining_amount > 0 {
-            let pull_amount = min(self.enqueued_for_cooldown_amount, remaining_amount);
-            self.enqueued_for_cooldown_amount = self
-                .enqueued_for_cooldown_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-            self.enqueued_for_withdraw_amount = self
-                .enqueued_for_withdraw_amount
-                .checked_add(pull_amount)
-                .ok_or(VaultError::VaultSecurityOverflow)?;
-            remaining_amount = remaining_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-        }
-        // staked_amount -> enqueued_for_withdraw_amount (cooling down)
-        if self.staked_amount > 0 && remaining_amount > 0 {
-            let pull_amount = min(self.staked_amount, remaining_amount);
-            self.staked_amount = self
-                .staked_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-            self.enqueued_for_withdraw_amount = self
-                .enqueued_for_withdraw_amount
-                .checked_add(pull_amount)
-                .ok_or(VaultError::VaultSecurityOverflow)?;
-            remaining_amount = remaining_amount
-                .checked_sub(pull_amount)
-                .ok_or(VaultError::VaultSecurityUnderflow)?;
-        }
-
-        if remaining_amount > 0 {
-            msg!("Failed to withdraw all the requested amount");
-            return Err(VaultError::VaultSecurityUnderflow);
-        }
-
-        Ok(())
-    }
-
     /// Delegates assets to the operator
     pub fn delegate(&mut self, amount: u64) -> Result<(), VaultError> {
         self.staked_amount = self
@@ -274,8 +157,6 @@ mod tests {
             staked_amount: 1,
             enqueued_for_cooldown_amount: 2,
             cooling_down_amount: 3,
-            enqueued_for_withdraw_amount: 4,
-            cooling_down_for_withdraw_amount: 5,
         };
         let copy = delegation_state.clone();
         delegation_state.subtract(&copy).unwrap();
@@ -288,22 +169,16 @@ mod tests {
             staked_amount: 10,
             enqueued_for_cooldown_amount: 20,
             cooling_down_amount: 30,
-            enqueued_for_withdraw_amount: 40,
-            cooling_down_for_withdraw_amount: 50,
         };
         let delegation_state_2 = DelegationState {
             staked_amount: 5,
             enqueued_for_cooldown_amount: 10,
             cooling_down_amount: 15,
-            enqueued_for_withdraw_amount: 20,
-            cooling_down_for_withdraw_amount: 25,
         };
         delegation_state_1.subtract(&delegation_state_2).unwrap();
         assert_eq!(delegation_state_1.staked_amount, 5);
         assert_eq!(delegation_state_1.enqueued_for_cooldown_amount, 10);
         assert_eq!(delegation_state_1.cooling_down_amount, 15);
-        assert_eq!(delegation_state_1.enqueued_for_withdraw_amount, 20);
-        assert_eq!(delegation_state_1.cooling_down_for_withdraw_amount, 25);
     }
 
     #[test]
@@ -336,53 +211,5 @@ mod tests {
         assert_eq!(delegation_state.enqueued_for_cooldown_amount, 0);
         assert_eq!(delegation_state.cooling_down_amount, 0);
         assert_eq!(delegation_state.total_security().unwrap(), 50);
-    }
-
-    #[test]
-    fn test_delegate_cooling_down_for_withdraw() {
-        let mut delegation_state = DelegationState::default();
-
-        delegation_state.delegate(100).unwrap();
-
-        delegation_state.cooldown_for_withdrawal(50).unwrap();
-        assert_eq!(delegation_state.staked_amount, 50);
-        assert_eq!(delegation_state.enqueued_for_withdraw_amount, 50);
-        assert_eq!(delegation_state.total_security().unwrap(), 100);
-
-        delegation_state.update();
-        assert_eq!(delegation_state.staked_amount, 50);
-        assert_eq!(delegation_state.enqueued_for_withdraw_amount, 0);
-        assert_eq!(delegation_state.cooling_down_for_withdraw_amount, 50);
-        assert_eq!(delegation_state.total_security().unwrap(), 100);
-
-        delegation_state.update();
-        assert_eq!(delegation_state.staked_amount, 50);
-        assert_eq!(delegation_state.enqueued_for_withdraw_amount, 0);
-        assert_eq!(delegation_state.cooling_down_for_withdraw_amount, 0);
-        assert_eq!(delegation_state.total_security().unwrap(), 50);
-    }
-
-    #[test]
-    fn test_delegate_cooling_down_for_withdraw_fund_transfer() {
-        let mut delegation_state = DelegationState {
-            staked_amount: 100,
-            enqueued_for_cooldown_amount: 50,
-            cooling_down_amount: 25,
-            enqueued_for_withdraw_amount: 0,
-            cooling_down_for_withdraw_amount: 0,
-        };
-
-        delegation_state.cooldown_for_withdrawal(150).unwrap();
-
-        assert_eq!(
-            delegation_state,
-            DelegationState {
-                staked_amount: 25,
-                enqueued_for_cooldown_amount: 0,
-                cooling_down_amount: 0,
-                enqueued_for_withdraw_amount: 125,
-                cooling_down_for_withdraw_amount: 25,
-            }
-        );
     }
 }

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -484,13 +484,12 @@ impl Vault {
         })
     }
 
-    pub fn delegate(&mut self, amount: u64) -> Result<(), VaultError> {
-        if self.tokens_deposited == 0 || self.vrt_supply == 0 {
-            msg!("No tokens deposited in vault");
-            return Err(VaultError::VaultUnderflow);
+    /// Calculates the amount of tokens, denominated in the supported_mint asset,
+    /// that should be reserved for the VRTs in the vault
+    pub fn calculate_vrt_reserve_amount(&self) -> Result<u64, VaultError> {
+        if self.vrt_supply == 0 {
+            return Ok(0);
         }
-
-        // there is some protection built-in to the vault to avoid over delegating assets
         let vrt_reserve = self
             .vrt_cooling_down_amount
             .checked_add(self.vrt_ready_to_claim_amount)
@@ -500,6 +499,87 @@ impl Vault {
             .checked_mul(self.tokens_deposited)
             .and_then(|x| x.checked_div(self.vrt_supply))
             .ok_or(VaultError::VaultOverflow)?;
+
+        let fee_amount = self.calculate_withdraw_fee(amount_to_reserve_for_vrts)?;
+        amount_to_reserve_for_vrts
+            .checked_sub(fee_amount)
+            .ok_or(VaultError::VaultUnderflow)
+    }
+
+    pub fn calculate_assets_needed_for_withdrawals(
+        &self,
+        slot: u64,
+        epoch_length: u64,
+    ) -> Result<u64, VaultError> {
+        // Calculate the total amount of assets needed to be set aside for all potential withdrawals
+        let amount_needed_set_aside_for_withdrawals = self.calculate_vrt_reserve_amount()?;
+
+        // Clone the current delegation state to simulate updates without modifying the original
+        let mut delegation_state_after_update = self.delegation_state;
+
+        // Calculate the epoch of the last full state update and the current epoch
+        let last_epoch_update = self
+            .last_full_state_update_slot
+            .checked_div(epoch_length)
+            .unwrap();
+        let this_epoch = slot.checked_div(epoch_length).unwrap();
+
+        // Update the simulated delegation state based on the number of epochs passed
+        let epoch_diff = this_epoch.checked_sub(last_epoch_update).unwrap();
+        match epoch_diff {
+            0 => {
+                // no-op
+            }
+            1 => {
+                delegation_state_after_update.update();
+            }
+            _ => {
+                // More than one epoch has passed, but we only need to update twice at most
+                // (enqueued -> cooling down and cooling down -> not allocated)
+                delegation_state_after_update.update();
+                delegation_state_after_update.update();
+            }
+        }
+
+        // Calculate the total amount of assets delegated after the simulated update
+        let total_delegated_after_update = delegation_state_after_update.total_security()?;
+
+        // Calculate the amount of assets that are not delegated after the simulated update
+        let undelegated_after_update = self
+            .tokens_deposited
+            .checked_sub(total_delegated_after_update)
+            .ok_or(VaultError::VaultUnderflow)?;
+
+        // Calculate the total amount of assets that are in the process of being withdrawn
+        // after the simulated update
+        let assets_withdrawing_after_update = delegation_state_after_update
+            .enqueued_for_cooldown_amount
+            .checked_add(delegation_state_after_update.cooling_down_amount)
+            .ok_or(VaultError::VaultOverflow)?;
+
+        // Calculate the total amount of assets available for withdrawal, which includes
+        // both undelegated assets and assets in the withdrawal process
+        let available_for_withdrawal = undelegated_after_update
+            .checked_add(assets_withdrawing_after_update)
+            .ok_or(VaultError::VaultOverflow)?;
+
+        // Calculate how many additional assets need to be undelegated to meet the withdrawal needs
+        // If available assets exceed the needed amount, this will be zero due to saturating subtraction
+        let additional_assets_need_undelegating =
+            amount_needed_set_aside_for_withdrawals.saturating_sub(available_for_withdrawal);
+
+        Ok(additional_assets_need_undelegating)
+    }
+
+    pub fn delegate(&mut self, amount: u64) -> Result<(), VaultError> {
+        if self.tokens_deposited == 0 || self.vrt_supply == 0 {
+            msg!("No tokens deposited in vault");
+            return Err(VaultError::VaultUnderflow);
+        }
+
+        // there is some protection built-in to the vault to avoid over delegating assets
+        // this numer is denominated in the supported token units
+        let amount_to_reserve_for_vrts = self.calculate_vrt_reserve_amount()?;
 
         let amount_available_for_delegation = self
             .tokens_deposited
@@ -597,6 +677,30 @@ mod tests {
         vault::{BurnSummary, MintSummary, Vault},
     };
 
+    fn make_test_vault(
+        deposit_fee_bps: u16,
+        withdraw_fee_bps: u16,
+        tokens_deposited: u64,
+        vrt_supply: u64,
+        delegation_state: DelegationState,
+    ) -> Vault {
+        let mut vault = Vault::new(
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            0,
+            Pubkey::new_unique(),
+            deposit_fee_bps,
+            withdraw_fee_bps,
+            0,
+        );
+
+        vault.tokens_deposited = tokens_deposited;
+        vault.vrt_supply = vrt_supply;
+        vault.delegation_state = delegation_state;
+        vault
+    }
+
     #[test]
     fn test_update_secondary_admin_ok() {
         let old_admin = Pubkey::new_unique();
@@ -638,16 +742,7 @@ mod tests {
 
     #[test]
     fn test_mint_simple_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
         let MintSummary {
             vrt_to_depositor,
             vrt_to_fee_wallet,
@@ -658,16 +753,7 @@ mod tests {
 
     #[test]
     fn test_mint_with_deposit_fee_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            100,
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(100, 0, 0, 0, DelegationState::default());
         let MintSummary {
             vrt_to_depositor,
             vrt_to_fee_wallet,
@@ -680,16 +766,7 @@ mod tests {
 
     #[test]
     fn test_mint_less_than_slippage_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            100,
-            1,
-            0,
-        );
+        let mut vault = make_test_vault(100, 0, 0, 0, DelegationState::default());
         assert_eq!(
             vault.mint_with_fee(100, 100),
             Err(VaultError::SlippageError)
@@ -698,18 +775,7 @@ mod tests {
 
     #[test]
     fn test_deposit_ratio_after_slashed_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 90;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 0, 90, 100, DelegationState::default());
 
         let MintSummary {
             vrt_to_depositor, ..
@@ -721,18 +787,7 @@ mod tests {
 
     #[test]
     fn test_deposit_ratio_after_reward_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 200;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 0, 200, 100, DelegationState::default());
 
         let MintSummary {
             vrt_to_depositor, ..
@@ -848,18 +903,7 @@ mod tests {
 
     #[test]
     fn test_burn_with_fee_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            100,
-            0,
-        );
-        vault.tokens_deposited = 100;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 100, 100, 100, DelegationState::default());
 
         let BurnSummary {
             fee_amount,
@@ -873,18 +917,7 @@ mod tests {
 
     #[test]
     fn test_burn_too_much_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            100,
-            0,
-        );
-        vault.tokens_deposited = 100;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 100, 100, 100, DelegationState::default());
 
         assert_eq!(
             vault.burn_with_fee(101, 100),
@@ -894,35 +927,13 @@ mod tests {
 
     #[test]
     fn test_burn_zero_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            100,
-            0,
-        );
-        vault.tokens_deposited = 100;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 100, 100, 100, DelegationState::default());
         assert_eq!(vault.burn_with_fee(0, 0), Err(VaultError::VaultUnderflow));
     }
 
     #[test]
     fn test_burn_slippage_exceeded_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            100,
-            0,
-        );
-        vault.tokens_deposited = 100;
-        vault.vrt_supply = 100;
+        let mut vault = make_test_vault(0, 100, 100, 100, DelegationState::default());
         assert_eq!(
             vault.burn_with_fee(100, 100),
             Err(VaultError::SlippageError)
@@ -931,26 +942,17 @@ mod tests {
 
     #[test]
     fn test_burn_with_delegation_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            100,
+            100,
+            DelegationState {
+                staked_amount: 10,
+                enqueued_for_cooldown_amount: 10,
+                cooling_down_amount: 10,
+            },
         );
-        vault.vrt_supply = 100;
-        vault.tokens_deposited = 100;
-
-        vault.delegation_state = DelegationState {
-            staked_amount: 10,
-            enqueued_for_cooldown_amount: 10,
-            cooling_down_amount: 10,
-            enqueued_for_withdraw_amount: 10,
-            cooling_down_for_withdraw_amount: 10,
-        };
 
         let BurnSummary {
             fee_amount,
@@ -966,51 +968,34 @@ mod tests {
 
     #[test]
     fn test_burn_more_than_withdrawable_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            100,
+            100,
+            DelegationState {
+                staked_amount: 50,
+                enqueued_for_cooldown_amount: 0,
+                cooling_down_amount: 0,
+            },
         );
-        vault.vrt_supply = 100;
-        vault.tokens_deposited = 100;
-
-        vault.delegation_state = DelegationState {
-            staked_amount: 10,
-            enqueued_for_cooldown_amount: 10,
-            cooling_down_amount: 10,
-            enqueued_for_withdraw_amount: 10,
-            cooling_down_for_withdraw_amount: 10,
-        };
 
         assert_eq!(vault.burn_with_fee(51, 50), Err(VaultError::VaultUnderflow));
     }
 
     #[test]
     fn test_burn_all_delegated() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            100,
+            100,
+            DelegationState {
+                staked_amount: 100,
+                enqueued_for_cooldown_amount: 0,
+                cooling_down_amount: 0,
+            },
         );
-        vault.vrt_supply = 100;
-        vault.tokens_deposited = 100;
-        vault.delegation_state = DelegationState {
-            staked_amount: 100,
-            enqueued_for_cooldown_amount: 0,
-            cooling_down_amount: 0,
-            enqueued_for_withdraw_amount: 0,
-            cooling_down_for_withdraw_amount: 0,
-        };
 
         let result = vault.burn_with_fee(1, 0);
         assert_eq!(result, Err(VaultError::VaultUnderflow));
@@ -1018,18 +1003,7 @@ mod tests {
 
     #[test]
     fn test_burn_rounding_issues() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.vrt_supply = 1_000_000;
-        vault.tokens_deposited = 1_000_000;
+        let mut vault = make_test_vault(0, 0, 1_000_000, 1_000_000, DelegationState::default());
 
         let result = vault.burn_with_fee(1, 0).unwrap();
         assert_eq!(result.out_amount, 1);
@@ -1039,18 +1013,7 @@ mod tests {
 
     #[test]
     fn test_burn_max_values() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.vrt_supply = u64::MAX;
-        vault.tokens_deposited = u64::MAX;
+        let mut vault = make_test_vault(0, 0, u64::MAX, u64::MAX, DelegationState::default());
 
         assert_eq!(
             vault.burn_with_fee(u64::MAX, u64::MAX - 1).unwrap_err(),
@@ -1060,18 +1023,7 @@ mod tests {
 
     #[test]
     fn test_burn_different_fees() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            500, // 5% withdrawal fee
-            0,
-        );
-        vault.vrt_supply = 10000;
-        vault.tokens_deposited = 10000;
+        let mut vault = make_test_vault(0, 500, 10000, 10000, DelegationState::default());
 
         let result = vault.burn_with_fee(1000, 900).unwrap();
         assert_eq!(result.fee_amount, 50);
@@ -1081,19 +1033,8 @@ mod tests {
 
     #[test]
     fn test_mint_at_max_capacity() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(0, 0, 900, 1000, DelegationState::default());
         vault.capacity = 1000;
-        vault.vrt_supply = 1000;
-        vault.tokens_deposited = 900;
 
         let result = vault.mint_with_fee(100, 111).unwrap();
         assert_eq!(result.vrt_to_depositor, 111);
@@ -1106,18 +1047,7 @@ mod tests {
 
     #[test]
     fn test_mint_small_amounts() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 1_000_000;
-        vault.vrt_supply = 1_000_000;
+        let mut vault = make_test_vault(0, 0, 1_000_000, 1_000_000, DelegationState::default());
 
         let result = vault.mint_with_fee(1, 1).unwrap();
         assert_eq!(result.vrt_to_depositor, 1);
@@ -1127,16 +1057,7 @@ mod tests {
 
     #[test]
     fn test_mint_different_fees() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            500, // 5% deposit fee
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(500, 0, 0, 0, DelegationState::default());
 
         let result = vault.mint_with_fee(1000, 950).unwrap();
         assert_eq!(result.vrt_to_depositor, 950);
@@ -1147,16 +1068,7 @@ mod tests {
 
     #[test]
     fn test_mint_empty_vault() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
 
         let result = vault.mint_with_fee(1000, 1000).unwrap();
         assert_eq!(result.vrt_to_depositor, 1000);
@@ -1167,18 +1079,7 @@ mod tests {
 
     #[test]
     fn test_mint_slippage_protection() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            100, // 1% deposit fee
-            0,
-            0,
-        );
-        vault.tokens_deposited = 10000;
-        vault.vrt_supply = 10000;
+        let mut vault = make_test_vault(100, 0, 0, 0, DelegationState::default());
 
         // Successful mint within slippage tolerance
         let result = vault.mint_with_fee(1000, 990).unwrap();
@@ -1191,16 +1092,7 @@ mod tests {
 
     #[test]
     fn test_mint_small_fee() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            1,
-            0,
-            0,
-        );
+        let mut vault = make_test_vault(1, 0, 0, 0, DelegationState::default());
         let MintSummary {
             vrt_to_depositor,
             vrt_to_fee_wallet,
@@ -1211,16 +1103,8 @@ mod tests {
 
     #[test]
     fn test_burn_small_fee() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            1,
-            0,
-        );
+        let mut vault = make_test_vault(0, 1, 0, 0, DelegationState::default());
+
         vault.mint_with_fee(1, 1).unwrap();
         let BurnSummary {
             fee_amount,
@@ -1234,35 +1118,14 @@ mod tests {
 
     #[test]
     fn test_delegate_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
+        let mut vault = make_test_vault(0, 0, 1000, 1000, DelegationState::default());
+
         vault.delegate(1000).unwrap();
     }
 
     #[test]
     fn test_delegate_more_than_available_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
+        let mut vault = make_test_vault(0, 0, 1000, 1000, DelegationState::default());
         assert_eq!(
             vault.delegate(1001),
             Err(VaultError::VaultInsufficientFunds)
@@ -1271,66 +1134,39 @@ mod tests {
 
     #[test]
     fn test_delegate_more_than_available_with_delegate_state_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 500,
+                enqueued_for_cooldown_amount: 200,
+                cooling_down_amount: 200,
+            },
         );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
-        vault.delegation_state = DelegationState {
-            staked_amount: 500,
-            enqueued_for_cooldown_amount: 200,
-            cooling_down_amount: 100,
-            enqueued_for_withdraw_amount: 100,
-            cooling_down_for_withdraw_amount: 0,
-        };
         assert_eq!(vault.delegate(101), Err(VaultError::VaultInsufficientFunds));
     }
 
     #[test]
     fn test_delegate_with_delegate_state_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 500,
+                enqueued_for_cooldown_amount: 200,
+                cooling_down_amount: 100,
+            },
         );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
-        vault.delegation_state = DelegationState {
-            staked_amount: 500,
-            enqueued_for_cooldown_amount: 200,
-            cooling_down_amount: 100,
-            enqueued_for_withdraw_amount: 100,
-            cooling_down_for_withdraw_amount: 0,
-        };
         vault.delegate(100).unwrap();
     }
 
     #[test]
     fn test_delegate_with_vrt_reserves_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
+        let mut vault = make_test_vault(0, 0, 1000, 1000, DelegationState::default());
         vault.vrt_ready_to_claim_amount = 100;
 
         vault.delegate(900).unwrap();
@@ -1338,18 +1174,7 @@ mod tests {
 
     #[test]
     fn test_delegate_more_than_vrt_reserves_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
-            0,
-            0,
-            0,
-        );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
+        let mut vault = make_test_vault(0, 0, 1000, 1000, DelegationState::default());
         vault.vrt_ready_to_claim_amount = 100;
 
         assert_eq!(vault.delegate(901), Err(VaultError::VaultInsufficientFunds));
@@ -1357,78 +1182,162 @@ mod tests {
 
     #[test]
     fn test_delegate_with_vrt_reserves_and_delegated_assets_ok() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 100,
+                enqueued_for_cooldown_amount: 100,
+                cooling_down_amount: 100,
+            },
         );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
         vault.vrt_ready_to_claim_amount = 100;
-        vault.delegation_state = DelegationState {
-            staked_amount: 100,
-            enqueued_for_cooldown_amount: 100,
-            cooling_down_amount: 100,
-            enqueued_for_withdraw_amount: 100,
-            cooling_down_for_withdraw_amount: 100,
-        };
 
         vault.delegate(400).unwrap();
     }
 
     #[test]
     fn test_delegate_with_vrt_reserves_and_delegated_assets_too_much_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 100,
+                enqueued_for_cooldown_amount: 100,
+                cooling_down_amount: 100,
+            },
         );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 1000;
         vault.vrt_ready_to_claim_amount = 100;
-        vault.delegation_state = DelegationState {
-            staked_amount: 100,
-            enqueued_for_cooldown_amount: 100,
-            cooling_down_amount: 100,
-            enqueued_for_withdraw_amount: 100,
-            cooling_down_for_withdraw_amount: 100,
-        };
 
         assert_eq!(vault.delegate(601), Err(VaultError::VaultInsufficientFunds));
     }
 
     #[test]
     fn test_delegate_with_vrt_reserves_and_delegated_assets_cooling_down_fails() {
-        let mut vault = Vault::new(
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            Pubkey::new_unique(),
-            0,
-            Pubkey::new_unique(),
+        let mut vault = make_test_vault(
             0,
             0,
-            0,
+            1000,
+            900,
+            DelegationState {
+                staked_amount: 0,
+                enqueued_for_cooldown_amount: 500,
+                cooling_down_amount: 0,
+            },
         );
-        vault.tokens_deposited = 1000;
-        vault.vrt_supply = 900;
         vault.vrt_ready_to_claim_amount = 500;
-        vault.delegation_state = DelegationState {
-            staked_amount: 0,
-            enqueued_for_cooldown_amount: 0,
-            cooling_down_amount: 0,
-            enqueued_for_withdraw_amount: 500,
-            cooling_down_for_withdraw_amount: 400,
-        };
         assert_eq!(vault.delegate(100), Err(VaultError::VaultUnderflow));
+    }
+
+    #[test]
+    fn test_calculate_vrt_reserve_amount_ok() {
+        let mut vault = make_test_vault(0, 0, 1000, 1000, DelegationState::default());
+        vault.vrt_cooling_down_amount = 100;
+        let result = vault.calculate_vrt_reserve_amount().unwrap();
+        assert_eq!(result, 100);
+    }
+
+    #[test]
+    fn test_calculate_vrt_reserve_amount_with_fee() {
+        let mut vault = make_test_vault(0, 100, 1000, 1000, DelegationState::default());
+        vault.vrt_cooling_down_amount = 100;
+        let result = vault.calculate_vrt_reserve_amount().unwrap();
+        assert_eq!(result, 99);
+    }
+
+    #[test]
+    fn test_calculate_assets_need_undelegating_ok() {
+        let mut vault = make_test_vault(
+            0,
+            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 1000,
+                enqueued_for_cooldown_amount: 0,
+                cooling_down_amount: 0,
+            },
+        );
+        vault.vrt_cooling_down_amount = 100;
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(100, 100)
+            .unwrap();
+        assert_eq!(result, 100);
+
+        vault.delegation_state.staked_amount = 900;
+        vault.delegation_state.cooling_down_amount = 100;
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(100, 100)
+            .unwrap();
+        assert_eq!(result, 0);
+
+        vault.vrt_cooling_down_amount = 200;
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(100, 100)
+            .unwrap();
+        assert_eq!(result, 100);
+    }
+
+    #[test]
+    fn test_calculate_assets_need_undelegating_with_assets_cooling_down() {
+        let mut vault = make_test_vault(
+            0,
+            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 900,
+                enqueued_for_cooldown_amount: 0,
+                cooling_down_amount: 100,
+            },
+        );
+        vault.vrt_cooling_down_amount = 100;
+
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(100, 100)
+            .unwrap();
+        assert_eq!(result, 0);
+
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(200, 100)
+            .unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_calculate_assets_need_undelegating_with_assets_cooling_down_2() {
+        let mut vault = make_test_vault(
+            0,
+            0,
+            1000,
+            1000,
+            DelegationState {
+                staked_amount: 800,
+                enqueued_for_cooldown_amount: 100,
+                cooling_down_amount: 100,
+            },
+        );
+        vault.vrt_cooling_down_amount = 300;
+
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(100, 100)
+            .unwrap();
+        assert_eq!(result, 100);
+
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(200, 100)
+            .unwrap();
+        assert_eq!(result, 100);
+
+        vault.vrt_supply += 100;
+        vault.tokens_deposited += 100;
+        let result = vault
+            .calculate_assets_needed_for_withdrawals(200, 100)
+            .unwrap();
+        assert_eq!(result, 0);
     }
 }

--- a/vault_core/src/vault_operator_delegation.rs
+++ b/vault_core/src/vault_operator_delegation.rs
@@ -60,8 +60,24 @@ impl VaultOperatorDelegation {
     /// The cooling_down_for_withdraw_amount becomes the enqueued_for_withdraw_amount
     /// The enqueued_for_withdraw_amount is zeroed out
     #[inline(always)]
-    pub fn update(&mut self, slot: u64) {
-        self.delegation_state.update();
+    pub fn update(&mut self, slot: u64, epoch_length: u64) {
+        let last_update_epoch = self.last_update_slot.checked_div(epoch_length).unwrap();
+        let current_epoch = slot.checked_div(epoch_length).unwrap();
+
+        let epoch_diff = current_epoch.checked_sub(last_update_epoch).unwrap();
+        match epoch_diff {
+            0 => {
+                // this shouldn't be possible
+            }
+            1 => {
+                self.delegation_state.update();
+            }
+            _ => {
+                // max 2 transitions needed
+                self.delegation_state.update();
+                self.delegation_state.update();
+            }
+        }
         self.last_update_slot = slot;
     }
 

--- a/vault_core/src/vault_operator_delegation.rs
+++ b/vault_core/src/vault_operator_delegation.rs
@@ -67,13 +67,13 @@ impl VaultOperatorDelegation {
         let epoch_diff = current_epoch.checked_sub(last_update_epoch).unwrap();
         match epoch_diff {
             0 => {
-                // this shouldn't be possible
+                // do nothing
             }
             1 => {
                 self.delegation_state.update();
             }
             _ => {
-                // max 2 transitions needed
+                // max 2 transitions needed (enqueued -> cooling down and cooling down -> not allocated)
                 self.delegation_state.update();
                 self.delegation_state.update();
             }

--- a/vault_core/src/vault_update_state_tracker.rs
+++ b/vault_core/src/vault_update_state_tracker.rs
@@ -1,8 +1,9 @@
-use crate::delegation_state::DelegationState;
 use bytemuck::{Pod, Zeroable};
 use jito_account_traits::{AccountDeserialize, Discriminator};
 use jito_vault_sdk::error::VaultError;
 use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
+
+use crate::delegation_state::DelegationState;
 
 impl Discriminator for VaultUpdateStateTracker {
     const DISCRIMINATOR: u8 = 9;
@@ -21,17 +22,32 @@ pub struct VaultUpdateStateTracker {
     /// The update index of the vault
     pub last_updated_index: u64,
 
+    /// The amount of additional assets that need unstaking to fulfill VRT withdrawals
+    pub additional_assets_need_unstaking: u64,
+
     /// The total amount delegated across all the operators in the vault
     pub delegation_state: DelegationState,
+
+    pub withdrawal_allocation_method: u8,
+
+    reserved: [u8; 7],
 }
 
 impl VaultUpdateStateTracker {
-    pub fn new(vault: Pubkey, ncn_epoch: u64) -> Self {
+    pub fn new(
+        vault: Pubkey,
+        ncn_epoch: u64,
+        additional_assets_need_unstaking: u64,
+        withdrawal_allocation_method: u8,
+    ) -> Self {
         Self {
             vault,
             ncn_epoch,
+            additional_assets_need_unstaking,
             last_updated_index: u64::MAX,
             delegation_state: DelegationState::default(),
+            withdrawal_allocation_method,
+            reserved: [0; 7],
         }
     }
 
@@ -43,7 +59,7 @@ impl VaultUpdateStateTracker {
             }
         } else if index != self.last_updated_index.checked_add(1).unwrap() {
             msg!("VaultUpdateStateTracker incorrect index");
-            return Err(VaultError::VaultUpdateIncorrectIndex.into());
+            return Err(VaultError::VaultUpdateIncorrectIndex);
         }
         self.last_updated_index = index;
         Ok(())
@@ -108,30 +124,23 @@ impl VaultUpdateStateTracker {
 
 #[cfg(test)]
 mod tests {
-    use crate::delegation_state::DelegationState;
-    use crate::vault_update_state_tracker::VaultUpdateStateTracker;
     use jito_vault_sdk::error::VaultError;
     use solana_program::pubkey::Pubkey;
 
+    use crate::vault_update_state_tracker::VaultUpdateStateTracker;
+
     #[test]
     fn test_update_index_zero_ok() {
-        let mut vault_update_state_tracker = VaultUpdateStateTracker {
-            vault: Pubkey::new_unique(),
-            ncn_epoch: 0,
-            last_updated_index: u64::MAX,
-            delegation_state: DelegationState::default(),
-        };
+        let mut vault_update_state_tracker =
+            VaultUpdateStateTracker::new(Pubkey::new_unique(), 0, 0, 0);
+
         assert!(vault_update_state_tracker.check_and_update_index(0).is_ok());
     }
 
     #[test]
     fn test_update_index_skip_zero_fails() {
-        let mut vault_update_state_tracker = VaultUpdateStateTracker {
-            vault: Pubkey::new_unique(),
-            ncn_epoch: 0,
-            last_updated_index: u64::MAX,
-            delegation_state: DelegationState::default(),
-        };
+        let mut vault_update_state_tracker =
+            VaultUpdateStateTracker::new(Pubkey::new_unique(), 0, 0, 0);
         assert_eq!(
             vault_update_state_tracker.check_and_update_index(1),
             Err(VaultError::VaultUpdateIncorrectIndex)
@@ -140,12 +149,8 @@ mod tests {
 
     #[test]
     fn test_update_index_skip_index_fails() {
-        let mut vault_update_state_tracker = VaultUpdateStateTracker {
-            vault: Pubkey::new_unique(),
-            ncn_epoch: 0,
-            last_updated_index: u64::MAX,
-            delegation_state: DelegationState::default(),
-        };
+        let mut vault_update_state_tracker =
+            VaultUpdateStateTracker::new(Pubkey::new_unique(), 0, 0, 0);
         vault_update_state_tracker
             .check_and_update_index(0)
             .unwrap();

--- a/vault_program/src/cooldown_delegation.rs
+++ b/vault_program/src/cooldown_delegation.rs
@@ -13,7 +13,6 @@ pub fn process_cooldown_delegation(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
     amount: u64,
-    for_withdrawal: bool,
 ) -> ProgramResult {
     let [config, vault_info, operator, vault_operator_delegation, vault_delegation_admin] =
         accounts
@@ -43,21 +42,10 @@ pub fn process_cooldown_delegation(
     vault.check_delegation_admin(vault_delegation_admin.key)?;
     vault.check_update_state_ok(Clock::get()?.slot, config.epoch_length)?;
 
-    vault
+    vault_operator_delegation
         .delegation_state
-        .subtract(&vault_operator_delegation.delegation_state)?;
-    if for_withdrawal {
-        vault_operator_delegation
-            .delegation_state
-            .cooldown_for_withdrawal(amount)?;
-    } else {
-        vault_operator_delegation
-            .delegation_state
-            .cooldown(amount)?;
-    }
-    vault
-        .delegation_state
-        .accumulate(&vault_operator_delegation.delegation_state)?;
+        .cooldown(amount)?;
+    vault.delegation_state.cooldown(amount)?;
 
     Ok(())
 }

--- a/vault_program/src/crank_vault_update_state_tracker.rs
+++ b/vault_program/src/crank_vault_update_state_tracker.rs
@@ -1,11 +1,14 @@
+use std::cmp::min;
+
 use jito_account_traits::AccountDeserialize;
 use jito_restaking_core::operator::Operator;
 use jito_vault_core::{
     config::Config, vault::Vault, vault_operator_delegation::VaultOperatorDelegation,
     vault_update_state_tracker::VaultUpdateStateTracker,
 };
+use jito_vault_sdk::{error::VaultError, instruction::WithdrawalAllocationMethod};
 use solana_program::{
-    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
+    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult, msg,
     program_error::ProgramError, pubkey::Pubkey, sysvar::Sysvar,
 };
 
@@ -13,7 +16,8 @@ pub fn process_crank_vault_update_state_tracker(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
 ) -> ProgramResult {
-    let [config, vault, operator, vault_operator_delegation, vault_update_state_tracker] = accounts
+    let [config, vault_info, operator, vault_operator_delegation, vault_update_state_tracker] =
+        accounts
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
@@ -23,9 +27,15 @@ pub fn process_crank_vault_update_state_tracker(
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();
     let config = Config::try_from_slice_unchecked(&config_data)?;
-    Vault::load(program_id, vault, false)?;
+    Vault::load(program_id, vault_info, false)?;
     Operator::load(&config.restaking_program, operator, false)?;
-    VaultOperatorDelegation::load(program_id, vault_operator_delegation, vault, operator, true)?;
+    VaultOperatorDelegation::load(
+        program_id,
+        vault_operator_delegation,
+        vault_info,
+        operator,
+        true,
+    )?;
     let mut vault_operator_delegation_data = vault_operator_delegation.data.borrow_mut();
     let vault_operator_delegation =
         VaultOperatorDelegation::try_from_slice_unchecked_mut(&mut vault_operator_delegation_data)?;
@@ -33,7 +43,7 @@ pub fn process_crank_vault_update_state_tracker(
     VaultUpdateStateTracker::load(
         program_id,
         vault_update_state_tracker,
-        vault,
+        vault_info,
         ncn_epoch,
         true,
     )?;
@@ -43,6 +53,40 @@ pub fn process_crank_vault_update_state_tracker(
     )?;
 
     vault_update_state_tracker.check_and_update_index(vault_operator_delegation.index)?;
+
+    match WithdrawalAllocationMethod::try_from(
+        vault_update_state_tracker.withdrawal_allocation_method,
+    ) {
+        Ok(WithdrawalAllocationMethod::Greedy) => {
+            if vault_update_state_tracker.additional_assets_need_unstaking > 0 {
+                let max_cooldown = min(
+                    vault_operator_delegation.delegation_state.staked_amount,
+                    vault_update_state_tracker.additional_assets_need_unstaking,
+                );
+                msg!(
+                    "Force cooling down {} assets from operator {}",
+                    max_cooldown,
+                    vault_operator_delegation.operator
+                );
+                vault_operator_delegation
+                    .delegation_state
+                    .cooldown(max_cooldown)?;
+                vault_update_state_tracker.additional_assets_need_unstaking =
+                    vault_update_state_tracker
+                        .additional_assets_need_unstaking
+                        .checked_sub(max_cooldown)
+                        .ok_or(VaultError::VaultUnderflow)?;
+            }
+        }
+        Err(e) => {
+            msg!(
+                "Invalid withdrawal allocation method: {:?}",
+                vault_update_state_tracker.withdrawal_allocation_method
+            );
+            return Err(e);
+        }
+    }
+
     vault_operator_delegation.update(slot, config.epoch_length);
     vault_update_state_tracker
         .delegation_state

--- a/vault_program/src/crank_vault_update_state_tracker.rs
+++ b/vault_program/src/crank_vault_update_state_tracker.rs
@@ -4,9 +4,8 @@ use jito_vault_core::{
     config::Config, vault::Vault, vault_operator_delegation::VaultOperatorDelegation,
     vault_update_state_tracker::VaultUpdateStateTracker,
 };
-use jito_vault_sdk::error::VaultError;
 use solana_program::{
-    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult, msg,
+    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
     program_error::ProgramError, pubkey::Pubkey, sysvar::Sysvar,
 };
 
@@ -43,49 +42,11 @@ pub fn process_crank_vault_update_state_tracker(
         &mut vault_update_state_tracker_data,
     )?;
 
-    if vault_update_state_tracker.last_updated_index == u64::MAX {
-        if vault_operator_delegation.index != 0 {
-            msg!("VaultUpdateStateTracker incorrect index");
-            return Err(VaultError::VaultUpdateIncorrectIndex.into());
-        }
-    } else if vault_operator_delegation.index
-        != vault_update_state_tracker
-            .last_updated_index
-            .checked_add(1)
-            .unwrap()
-    {
-        msg!("VaultUpdateStateTracker incorrect index");
-        return Err(VaultError::VaultUpdateIncorrectIndex.into());
-    }
-
-    // There's a possibility the VaultOperatorDelegation was partially updated in the past, so to avoid
-    // over-updating it, we look at the last_update_slot in the VaultOperatorDelegation to calculate the
-    // last update epoch instead of looking at the epoch in the VaultUpdateStateTracker
-    let last_update_epoch = vault_operator_delegation
-        .last_update_slot
-        .checked_div(config.epoch_length)
-        .unwrap();
-    let current_epoch = slot.checked_div(config.epoch_length).unwrap();
-
-    let epoch_diff = current_epoch.checked_sub(last_update_epoch).unwrap();
-    match epoch_diff {
-        0 => {
-            // this shouldn't be possible
-        }
-        1 => {
-            vault_operator_delegation.update(slot);
-        }
-        _ => {
-            // max 2 transitions needeed
-            vault_operator_delegation.update(slot);
-            vault_operator_delegation.update(slot);
-        }
-    }
-
+    vault_update_state_tracker.check_and_update_index(vault_operator_delegation.index)?;
+    vault_operator_delegation.update(slot, config.epoch_length);
     vault_update_state_tracker
         .delegation_state
         .accumulate(&vault_operator_delegation.delegation_state)?;
-    vault_update_state_tracker.last_updated_index = vault_operator_delegation.index;
 
     Ok(())
 }

--- a/vault_program/src/lib.rs
+++ b/vault_program/src/lib.rs
@@ -206,20 +206,23 @@ pub fn process_instruction(
             msg!("Instruction: AddDelegation");
             process_add_delegation(program_id, accounts, amount)
         }
-        VaultInstruction::CooldownDelegation {
-            amount,
-            for_withdrawal,
-        } => {
+        VaultInstruction::CooldownDelegation { amount } => {
             msg!("Instruction: CooldownDelegation");
-            process_cooldown_delegation(program_id, accounts, amount, for_withdrawal)
+            process_cooldown_delegation(program_id, accounts, amount)
         }
         VaultInstruction::UpdateVaultBalance => {
             msg!("Instruction: UpdateVaultBalance");
             process_update_vault_balance(program_id, accounts)
         }
-        VaultInstruction::InitializeVaultUpdateStateTracker => {
+        VaultInstruction::InitializeVaultUpdateStateTracker {
+            withdrawal_allocation_method,
+        } => {
             msg!("Instruction: InitializeVaultUpdateStateTracker");
-            process_initialize_vault_update_state_tracker(program_id, accounts)
+            process_initialize_vault_update_state_tracker(
+                program_id,
+                accounts,
+                withdrawal_allocation_method,
+            )
         }
         VaultInstruction::CrankVaultUpdateStateTracker => {
             msg!("Instruction: CrankVaultUpdateStateTracker");

--- a/vault_program/src/update_vault_balance.rs
+++ b/vault_program/src/update_vault_balance.rs
@@ -1,11 +1,9 @@
 use jito_account_traits::AccountDeserialize;
 use jito_jsm_core::loader::load_associated_token_account;
 use jito_vault_core::{config::Config, vault::Vault};
-use solana_program::clock::Clock;
-use solana_program::sysvar::Sysvar;
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
-    program_pack::Pack, pubkey::Pubkey,
+    account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult,
+    program_error::ProgramError, program_pack::Pack, pubkey::Pubkey, sysvar::Sysvar,
 };
 use spl_token::state::Account;
 
@@ -19,7 +17,7 @@ pub fn process_update_vault_balance(
 
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();
-    let config = Config::try_from_slice(&config_data)?;
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;

--- a/vault_program/src/update_vault_balance.rs
+++ b/vault_program/src/update_vault_balance.rs
@@ -1,6 +1,8 @@
 use jito_account_traits::AccountDeserialize;
 use jito_jsm_core::loader::load_associated_token_account;
 use jito_vault_core::{config::Config, vault::Vault};
+use solana_program::clock::Clock;
+use solana_program::sysvar::Sysvar;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
     program_pack::Pack, pubkey::Pubkey,
@@ -16,10 +18,14 @@ pub fn process_update_vault_balance(
     };
 
     Config::load(program_id, config, false)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice(&config_data)?;
     Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     load_associated_token_account(vault_token_account, vault_info.key, &vault.supported_mint)?;
+
+    vault.check_update_state_ok(Clock::get()?.slot, config.epoch_length)?;
 
     // TODO (LB): pay out fee account for any accrued fees to vault fee wallet
     vault.tokens_deposited = Account::unpack(&vault_token_account.data.borrow())?.amount;

--- a/vault_sdk/src/error.rs
+++ b/vault_sdk/src/error.rs
@@ -29,6 +29,7 @@ pub enum VaultError {
     VaultSecurityOverflow = 2022,
     VaultSlashIncomplete = 2023,
     VaultSecurityUnderflow = 2024,
+    SlippageError = 2025,
 
     VaultDelegationListOverflow = 3000,
     VaultDelegationListUnderflow = 3001,
@@ -60,7 +61,6 @@ pub enum VaultError {
     VaultMaxSlashedPerOperatorExceeded = 4019,
 
     VaultDelegationUpdateOverflow = 5000,
-    SlippageError,
 }
 
 impl From<VaultError> for ProgramError {

--- a/vault_sdk/src/instruction.rs
+++ b/vault_sdk/src/instruction.rs
@@ -1,5 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use shank::ShankInstruction;
+use solana_program::program_error::ProgramError;
 
 #[rustfmt::skip]
 #[derive(Debug, BorshSerialize, BorshDeserialize, ShankInstruction)]
@@ -228,7 +229,6 @@ pub enum VaultInstruction {
     #[account(4, signer, name = "admin")]
     CooldownDelegation {
         amount: u64,
-        for_withdrawal: bool
     },
 
     #[account(0, name = "config")]
@@ -242,7 +242,7 @@ pub enum VaultInstruction {
     #[account(2, writable, name = "vault_update_state_tracker")]
     #[account(3, writable, name = "payer")]
     #[account(4, name = "system_program")]
-    InitializeVaultUpdateStateTracker,
+    InitializeVaultUpdateStateTracker { withdrawal_allocation_method: WithdrawalAllocationMethod },
 
     /// Shall be called on every vault_operator_delegation
     #[account(0, name = "config")]
@@ -318,4 +318,23 @@ pub enum VaultAdminRole {
     MintBurnAdmin,
     WithdrawAdmin,
     FeeAdmin,
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+#[repr(u8)]
+pub enum WithdrawalAllocationMethod {
+    /// During withdrawal allocation, the greedy mode will subtract assets from operator delegations
+    /// its iterating over in order to fulfill the withdrawal.
+    Greedy,
+}
+
+impl TryFrom<u8> for WithdrawalAllocationMethod {
+    type Error = ProgramError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Greedy),
+            _ => Err(ProgramError::InvalidArgument),
+        }
+    }
 }

--- a/vault_sdk/src/sdk.rs
+++ b/vault_sdk/src/sdk.rs
@@ -7,7 +7,7 @@ use solana_program::{
 
 use crate::{
     inline_mpl_token_metadata::{self, pda::find_metadata_account},
-    instruction::{VaultAdminRole, VaultInstruction},
+    instruction::{VaultAdminRole, VaultInstruction, WithdrawalAllocationMethod},
 };
 
 pub fn initialize_config(
@@ -366,7 +366,6 @@ pub fn cooldown_delegation(
     vault_operator_delegation: &Pubkey,
     admin: &Pubkey,
     amount: u64,
-    for_withdrawal: bool,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new_readonly(*config, false),
@@ -378,12 +377,9 @@ pub fn cooldown_delegation(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: VaultInstruction::CooldownDelegation {
-            amount,
-            for_withdrawal,
-        }
-        .try_to_vec()
-        .unwrap(),
+        data: VaultInstruction::CooldownDelegation { amount }
+            .try_to_vec()
+            .unwrap(),
     }
 }
 
@@ -669,6 +665,7 @@ pub fn initialize_vault_update_state_tracker(
     vault: &Pubkey,
     vault_update_state_tracker: &Pubkey,
     payer: &Pubkey,
+    withdrawal_allocation_method: WithdrawalAllocationMethod,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new_readonly(*config, false),
@@ -680,9 +677,11 @@ pub fn initialize_vault_update_state_tracker(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: VaultInstruction::InitializeVaultUpdateStateTracker
-            .try_to_vec()
-            .unwrap(),
+        data: VaultInstruction::InitializeVaultUpdateStateTracker {
+            withdrawal_allocation_method,
+        }
+        .try_to_vec()
+        .unwrap(),
     }
 }
 


### PR DESCRIPTION
- Withdrawals need to be resistant to the delegation manager shutting down so funds don't get stuck.
- On epoch updates, if the delegation manager hasn't withdrawn funds for the VRTs pending redemption, this code will do it automatically.

Other things:
- Removes the concept of withdraw funds in the delegation state. Not needed anymore.