### PR TITLE
Ensure vault is writable

### DIFF
--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -16,7 +16,8 @@ use jito_vault_sdk::{
     inline_mpl_token_metadata,
     instruction::{VaultAdminRole, WithdrawalAllocationMethod},
     sdk::{
-        add_delegation, cooldown_delegation, initialize_config, initialize_vault, set_deposit_capacity, warmup_vault_ncn_slasher_ticket, warmup_vault_ncn_ticket
+        add_delegation, cooldown_delegation, initialize_config, initialize_vault,
+        set_deposit_capacity, warmup_vault_ncn_slasher_ticket, warmup_vault_ncn_ticket,
     },
 };
 use log::info;

--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -16,8 +16,7 @@ use jito_vault_sdk::{
     inline_mpl_token_metadata,
     instruction::{VaultAdminRole, WithdrawalAllocationMethod},
     sdk::{
-        add_delegation, cooldown_delegation, initialize_config, initialize_vault,
-        warmup_vault_ncn_slasher_ticket, warmup_vault_ncn_ticket,
+        add_delegation, cooldown_delegation, initialize_config, initialize_vault, set_deposit_capacity, warmup_vault_ncn_slasher_ticket, warmup_vault_ncn_ticket
     },
 };
 use log::info;
@@ -75,7 +74,7 @@ impl VaultProgramClient {
         depositor: &Pubkey,
         amount_to_mint: u64,
     ) -> TestResult<()> {
-        self._airdrop(depositor, 100.0).await?;
+        self.airdrop(depositor, 100.0).await?;
         let vault = self.get_vault(&vault_root.vault_pubkey).await?;
         self.create_ata(&vault.supported_mint, depositor).await?;
         self.create_ata(&vault.vrt_mint, depositor).await?;
@@ -219,7 +218,7 @@ impl VaultProgramClient {
     pub async fn do_initialize_config(&mut self) -> Result<Keypair, TestError> {
         let config_admin = Keypair::new();
 
-        self._airdrop(&config_admin.pubkey(), 1.0).await?;
+        self.airdrop(&config_admin.pubkey(), 1.0).await?;
 
         let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
         self.initialize_config(&config_pubkey, &config_admin)
@@ -265,7 +264,7 @@ impl VaultProgramClient {
         let vault_admin = Keypair::new();
         let token_mint = Keypair::new();
 
-        self._airdrop(&vault_admin.pubkey(), 100.0).await?;
+        self.airdrop(&vault_admin.pubkey(), 100.0).await?;
         self.create_token_mint(&token_mint).await?;
 
         self.initialize_vault(
@@ -325,6 +324,30 @@ impl VaultProgramClient {
         .await?;
 
         Ok(())
+    }
+
+    pub async fn set_capacity(
+        &mut self,
+        config: &Pubkey,
+        vault: &Pubkey,
+        admin: &Keypair,
+        capacity: u64,
+    ) -> Result<(), TestError> {
+        let blockhash = self.banks_client.get_latest_blockhash().await?;
+
+        self._process_transaction(&Transaction::new_signed_with_payer(
+            &[set_deposit_capacity(
+                &jito_vault_program::id(),
+                &config,
+                &vault,
+                &admin.pubkey(),
+                capacity,
+            )],
+            Some(&admin.pubkey()),
+            &[&admin],
+            blockhash,
+        ))
+        .await
     }
 
     pub async fn do_warmup_vault_ncn_ticket(
@@ -1474,7 +1497,7 @@ impl VaultProgramClient {
         Ok(())
     }
 
-    pub async fn _airdrop(&mut self, to: &Pubkey, sol: f64) -> Result<(), TestError> {
+    pub async fn airdrop(&mut self, to: &Pubkey, sol: f64) -> Result<(), TestError> {
         let blockhash = self.banks_client.get_latest_blockhash().await?;
         self.banks_client
             .process_transaction_with_preflight_and_commitment(

--- a/integration_tests/tests/vault/mod.rs
+++ b/integration_tests/tests/vault/mod.rs
@@ -13,6 +13,7 @@ mod initialize_vault_operator_delegation;
 mod initialize_vault_update_state_tracker;
 mod reward_fee;
 mod set_admin;
+mod set_capacity;
 mod set_fees;
 mod set_secondary_admin;
 mod slash;

--- a/integration_tests/tests/vault/set_admin.rs
+++ b/integration_tests/tests/vault/set_admin.rs
@@ -44,7 +44,7 @@ mod tests {
 
         let bad_admin = Keypair::new();
         vault_program_client
-            ._airdrop(&bad_admin.pubkey(), 10.0)
+            .airdrop(&bad_admin.pubkey(), 10.0)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/set_capacity.rs
+++ b/integration_tests/tests/vault/set_capacity.rs
@@ -1,0 +1,40 @@
+#[cfg(test)]
+mod tests {
+    use jito_vault_core::config::Config;
+    use jito_vault_sdk::error::VaultError;
+    use solana_sdk::{signature::Keypair, signer::Signer};
+
+    use crate::fixtures::{fixture::TestBuilder, vault_client::assert_vault_error};
+
+    #[tokio::test]
+    async fn test_set_capacity_ok() {
+        let fixture = TestBuilder::new().await;
+        let mut vault_program_client = fixture.vault_program_client();
+
+        let (_config_admin, vault_root) = vault_program_client.setup_config_and_vault(0,0,0).await.unwrap();
+
+        let vault = vault_program_client.get_vault(&vault_root.vault_pubkey).await.unwrap();
+        assert_eq!(vault.capacity(), u64::MAX);
+
+        let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
+        vault_program_client.set_capacity(&config_pubkey, &vault_root.vault_pubkey, &vault_root.vault_admin, 100).await.unwrap();
+
+        let vault = vault_program_client.get_vault(&vault_root.vault_pubkey).await.unwrap();
+        assert_eq!(vault.capacity(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_set_capacity_wrong_admin() {
+        let fixture = TestBuilder::new().await;
+        let mut vault_program_client = fixture.vault_program_client();
+
+        let (_config_admin, vault_root) = vault_program_client.setup_config_and_vault(0,0,0).await.unwrap();
+
+        let wrong_admin = Keypair::new();
+        vault_program_client.airdrop(&wrong_admin.pubkey(), 1.0).await.unwrap();
+
+        let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
+        let result = vault_program_client.set_capacity(&config_pubkey, &vault_root.vault_pubkey, &wrong_admin, 100).await;
+        assert_vault_error(result, VaultError::VaultCapacityAdminInvalid);
+    }
+}

--- a/integration_tests/tests/vault/set_capacity.rs
+++ b/integration_tests/tests/vault/set_capacity.rs
@@ -11,15 +11,32 @@ mod tests {
         let fixture = TestBuilder::new().await;
         let mut vault_program_client = fixture.vault_program_client();
 
-        let (_config_admin, vault_root) = vault_program_client.setup_config_and_vault(0,0,0).await.unwrap();
+        let (_config_admin, vault_root) = vault_program_client
+            .setup_config_and_vault(0, 0, 0)
+            .await
+            .unwrap();
 
-        let vault = vault_program_client.get_vault(&vault_root.vault_pubkey).await.unwrap();
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
         assert_eq!(vault.capacity(), u64::MAX);
 
         let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
-        vault_program_client.set_capacity(&config_pubkey, &vault_root.vault_pubkey, &vault_root.vault_admin, 100).await.unwrap();
+        vault_program_client
+            .set_capacity(
+                &config_pubkey,
+                &vault_root.vault_pubkey,
+                &vault_root.vault_admin,
+                100,
+            )
+            .await
+            .unwrap();
 
-        let vault = vault_program_client.get_vault(&vault_root.vault_pubkey).await.unwrap();
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
         assert_eq!(vault.capacity(), 100);
     }
 
@@ -28,13 +45,21 @@ mod tests {
         let fixture = TestBuilder::new().await;
         let mut vault_program_client = fixture.vault_program_client();
 
-        let (_config_admin, vault_root) = vault_program_client.setup_config_and_vault(0,0,0).await.unwrap();
+        let (_config_admin, vault_root) = vault_program_client
+            .setup_config_and_vault(0, 0, 0)
+            .await
+            .unwrap();
 
         let wrong_admin = Keypair::new();
-        vault_program_client.airdrop(&wrong_admin.pubkey(), 1.0).await.unwrap();
+        vault_program_client
+            .airdrop(&wrong_admin.pubkey(), 1.0)
+            .await
+            .unwrap();
 
         let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
-        let result = vault_program_client.set_capacity(&config_pubkey, &vault_root.vault_pubkey, &wrong_admin, 100).await;
+        let result = vault_program_client
+            .set_capacity(&config_pubkey, &vault_root.vault_pubkey, &wrong_admin, 100)
+            .await;
         assert_vault_error(result, VaultError::VaultCapacityAdminInvalid);
     }
 }

--- a/integration_tests/tests/vault/set_fees.rs
+++ b/integration_tests/tests/vault/set_fees.rs
@@ -290,7 +290,7 @@ mod tests {
         let bad_admin = Keypair::new();
         fixture
             .vault_program_client()
-            ._airdrop(&bad_admin.pubkey(), 10.0)
+            .airdrop(&bad_admin.pubkey(), 10.0)
             .await
             .unwrap();
 
@@ -395,7 +395,7 @@ mod tests {
         let new_admin = Keypair::new();
         fixture
             .vault_program_client()
-            ._airdrop(&new_admin.pubkey(), 10.0)
+            .airdrop(&new_admin.pubkey(), 10.0)
             .await
             .unwrap();
 
@@ -439,7 +439,7 @@ mod tests {
         let new_admin = Keypair::new();
         fixture
             .vault_program_client()
-            ._airdrop(&new_admin.pubkey(), 10.0)
+            .airdrop(&new_admin.pubkey(), 10.0)
             .await
             .unwrap();
 
@@ -502,7 +502,7 @@ mod tests {
         let new_admin = Keypair::new();
         fixture
             .vault_program_client()
-            ._airdrop(&new_admin.pubkey(), 10.0)
+            .airdrop(&new_admin.pubkey(), 10.0)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/set_secondary_admin.rs
+++ b/integration_tests/tests/vault/set_secondary_admin.rs
@@ -40,7 +40,7 @@ mod tests {
 
         let bad_admin = Keypair::new();
         vault_program_client
-            ._airdrop(&bad_admin.pubkey(), 10.0)
+            .airdrop(&bad_admin.pubkey(), 10.0)
             .await
             .unwrap();
 

--- a/vault_program/src/cooldown_delegation.rs
+++ b/vault_program/src/cooldown_delegation.rs
@@ -21,7 +21,7 @@ pub fn process_cooldown_delegation(
     };
 
     Config::load(program_id, config, false)?;
-    Vault::load(program_id, vault_info, false)?;
+    Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     let config_data = config.data.borrow();

--- a/vault_program/src/mint_to.rs
+++ b/vault_program/src/mint_to.rs
@@ -38,7 +38,7 @@ pub fn process_mint(
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();
     let config = Config::try_from_slice_unchecked(&config_data)?;
-    Vault::load(program_id, vault_info, false)?;
+    Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     load_token_mint(vrt_mint)?;

--- a/vault_program/src/set_admin.rs
+++ b/vault_program/src/set_admin.rs
@@ -12,7 +12,7 @@ pub fn process_set_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progr
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     Config::load(program_id, config, false)?;
-    Vault::load(program_id, vault, false)?;
+    Vault::load(program_id, vault, true)?;
     let mut vault_data = vault.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     load_signer(old_admin, false)?;

--- a/vault_program/src/set_capacity.rs
+++ b/vault_program/src/set_capacity.rs
@@ -15,7 +15,7 @@ pub fn process_set_deposit_capacity(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     Config::load(program_id, config, false)?;
-    Vault::load(program_id, vault, false)?;
+    Vault::load(program_id, vault, true)?;
     let mut vault_data = vault.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     load_signer(vault_capacity_admin, false)?;

--- a/vault_program/src/set_fees.rs
+++ b/vault_program/src/set_fees.rs
@@ -20,7 +20,7 @@ pub fn process_set_fees(
     Config::load(program_id, config, false)?;
     let mut config_data = config.data.borrow_mut();
     let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
-    Vault::load(program_id, vault, false)?;
+    Vault::load(program_id, vault, true)?;
     let mut vault_data = vault.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     load_signer(vault_fee_admin, false)?;

--- a/vault_program/src/slash.rs
+++ b/vault_program/src/slash.rs
@@ -32,7 +32,7 @@ pub fn process_slash(
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();
     let config = Config::try_from_slice_unchecked(&config_data)?;
-    Vault::load(program_id, vault_info, false)?;
+    Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     Ncn::load(&config.restaking_program, ncn, false)?;


### PR DESCRIPTION
Bug: Vault wasn't required to be writable during mutable instructions. Added expect writable = true to those instructions