### PR TITLE
Vault: Make fee logic easier to follow & bug fixes

### DIFF
--- a/clients/js/vault_client/accounts/config.ts
+++ b/clients/js/vault_client/accounts/config.ts
@@ -43,7 +43,7 @@ export type Config = {
   restakingProgram: Address;
   epochLength: bigint;
   numVaults: bigint;
-  feeCapBps: number;
+  depositWithdrawalFeeCapBps: number;
   feeRateOfChangeBps: number;
   feeBumpBps: number;
   bump: number;
@@ -56,7 +56,7 @@ export type ConfigArgs = {
   restakingProgram: Address;
   epochLength: number | bigint;
   numVaults: number | bigint;
-  feeCapBps: number;
+  depositWithdrawalFeeCapBps: number;
   feeRateOfChangeBps: number;
   feeBumpBps: number;
   bump: number;
@@ -70,7 +70,7 @@ export function getConfigEncoder(): Encoder<ConfigArgs> {
     ['restakingProgram', getAddressEncoder()],
     ['epochLength', getU64Encoder()],
     ['numVaults', getU64Encoder()],
-    ['feeCapBps', getU16Encoder()],
+    ['depositWithdrawalFeeCapBps', getU16Encoder()],
     ['feeRateOfChangeBps', getU16Encoder()],
     ['feeBumpBps', getU16Encoder()],
     ['bump', getU8Encoder()],
@@ -85,7 +85,7 @@ export function getConfigDecoder(): Decoder<Config> {
     ['restakingProgram', getAddressDecoder()],
     ['epochLength', getU64Decoder()],
     ['numVaults', getU64Decoder()],
-    ['feeCapBps', getU16Decoder()],
+    ['depositWithdrawalFeeCapBps', getU16Decoder()],
     ['feeRateOfChangeBps', getU16Decoder()],
     ['feeBumpBps', getU16Decoder()],
     ['bump', getU8Decoder()],

--- a/clients/rust/vault_client/src/generated/accounts/config.rs
+++ b/clients/rust/vault_client/src/generated/accounts/config.rs
@@ -23,7 +23,7 @@ pub struct Config {
     pub restaking_program: Pubkey,
     pub epoch_length: u64,
     pub num_vaults: u64,
-    pub fee_cap_bps: u16,
+    pub deposit_withdrawal_fee_cap_bps: u16,
     pub fee_rate_of_change_bps: u16,
     pub fee_bump_bps: u16,
     pub bump: u8,

--- a/idl/jito_vault.json
+++ b/idl/jito_vault.json
@@ -1419,7 +1419,7 @@
             }
           },
           {
-            "name": "feeCapBps",
+            "name": "depositWithdrawalFeeCapBps",
             "type": {
               "defined": "PodU16"
             }

--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -1,3 +1,5 @@
+use std::{fmt, fmt::Debug};
+
 use borsh::BorshDeserialize;
 use jito_bytemuck::AccountDeserialize;
 use jito_restaking_core::{
@@ -49,6 +51,16 @@ use crate::fixtures::{TestError, TestResult};
 pub struct VaultRoot {
     pub vault_pubkey: Pubkey,
     pub vault_admin: Keypair,
+}
+
+impl Debug for VaultRoot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "VaultRoot {{ vault_pubkey: {}, vault_admin: {:?} }}",
+            self.vault_pubkey, self.vault_admin
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -255,7 +267,19 @@ impl VaultProgramClient {
         reward_fee_bps: u16,
     ) -> Result<(Keypair, VaultRoot), TestError> {
         let config_admin = self.do_initialize_config().await?;
+        let vault_root = self
+            .do_initialize_vault(deposit_fee_bps, withdraw_fee_bps, reward_fee_bps)
+            .await?;
 
+        Ok((config_admin, vault_root))
+    }
+
+    pub async fn do_initialize_vault(
+        &mut self,
+        deposit_fee_bps: u16,
+        withdraw_fee_bps: u16,
+        reward_fee_bps: u16,
+    ) -> Result<VaultRoot, TestError> {
         let vault_base = Keypair::new();
 
         let vault_pubkey =
@@ -287,13 +311,10 @@ impl VaultProgramClient {
         self.create_ata(&vrt_mint.pubkey(), &vault_admin.pubkey())
             .await?;
 
-        Ok((
-            config_admin,
-            VaultRoot {
-                vault_admin,
-                vault_pubkey,
-            },
-        ))
+        Ok(VaultRoot {
+            vault_admin,
+            vault_pubkey,
+        })
     }
 
     pub async fn do_initialize_vault_ncn_ticket(

--- a/integration_tests/tests/vault/set_fees.rs
+++ b/integration_tests/tests/vault/set_fees.rs
@@ -582,8 +582,8 @@ mod tests {
             .await
             .unwrap();
 
-        let new_deposit_fee_bps = config.fee_cap_bps() + 1;
-        let new_withdrawal_fee_bps = config.fee_cap_bps() + 1;
+        let new_deposit_fee_bps = config.deposit_withdrawal_fee_cap_bps() + 1;
+        let new_withdrawal_fee_bps = config.deposit_withdrawal_fee_cap_bps() + 1;
         let new_reward_fee_bps = Config::MAX_BPS + 1;
 
         let result = fixture

--- a/integration_tests/tests/vault/set_fees.rs
+++ b/integration_tests/tests/vault/set_fees.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use jito_vault_core::config::Config;
+    use jito_vault_core::{config::Config, MAX_FEE_BPS};
     use jito_vault_sdk::{error::VaultError, instruction::VaultAdminRole};
     use solana_sdk::{
         pubkey::Pubkey,
@@ -584,7 +584,7 @@ mod tests {
 
         let new_deposit_fee_bps = config.deposit_withdrawal_fee_cap_bps() + 1;
         let new_withdrawal_fee_bps = config.deposit_withdrawal_fee_cap_bps() + 1;
-        let new_reward_fee_bps = Config::MAX_BPS + 1;
+        let new_reward_fee_bps = MAX_FEE_BPS + 1;
 
         let result = fixture
             .vault_program_client()
@@ -971,9 +971,9 @@ mod tests {
             .await
             .unwrap();
 
-        let new_deposit_fee_bps = Config::MAX_BPS + 1;
-        let new_withdrawal_fee_bps = Config::MAX_BPS + 1;
-        let new_reward_fee_bps = Config::MAX_BPS + 1;
+        let new_deposit_fee_bps = MAX_FEE_BPS + 1;
+        let new_withdrawal_fee_bps = MAX_FEE_BPS + 1;
+        let new_reward_fee_bps = MAX_FEE_BPS + 1;
 
         let result = fixture
             .vault_program_client()

--- a/vault_core/src/config.rs
+++ b/vault_core/src/config.rs
@@ -36,7 +36,7 @@ pub struct Config {
     num_vaults: PodU64,
 
     /// The fee cap in basis points ( withdraw and deposit )
-    fee_cap_bps: PodU16,
+    deposit_withdrawal_fee_cap_bps: PodU16,
 
     /// The maximum amount a fee can increase per epoch in basis points
     fee_rate_of_change_bps: PodU16,
@@ -68,7 +68,7 @@ impl Config {
             epoch_length: PodU64::from(DEFAULT_SLOTS_PER_EPOCH),
             num_vaults: PodU64::from(0),
             // Cannot be higher than 100%
-            fee_cap_bps: PodU16::from(Self::DEFAULT_FEES_CAP_BPS),
+            deposit_withdrawal_fee_cap_bps: PodU16::from(Self::DEFAULT_FEES_CAP_BPS),
             fee_rate_of_change_bps: PodU16::from(Self::DEFAULT_FEE_RATE_OF_CHANGE_BPS),
             fee_bump_bps: PodU16::from(Self::DEFAULT_FEE_BUMP_BPS),
             bump,
@@ -84,8 +84,8 @@ impl Config {
         self.num_vaults.into()
     }
 
-    pub fn fee_cap_bps(&self) -> u16 {
-        self.fee_cap_bps.into()
+    pub fn deposit_withdrawal_fee_cap_bps(&self) -> u16 {
+        self.deposit_withdrawal_fee_cap_bps.into()
     }
 
     pub fn fee_rate_of_change_bps(&self) -> u16 {

--- a/vault_core/src/config.rs
+++ b/vault_core/src/config.rs
@@ -58,8 +58,6 @@ impl Config {
     pub const DEFAULT_FEE_RATE_OF_CHANGE_BPS: u16 = 2_500; // 25%
     /// Maximum bump in fee change above the rate of change
     pub const DEFAULT_FEE_BUMP_BPS: u16 = 10; // 0.1%
-    /// 100% in basis points
-    pub const MAX_BPS: u16 = 10_000;
 
     pub fn new(admin: Pubkey, restaking_program: Pubkey, bump: u8) -> Self {
         Self {

--- a/vault_core/src/lib.rs
+++ b/vault_core/src/lib.rs
@@ -8,3 +8,5 @@ pub mod vault_ncn_ticket;
 pub mod vault_operator_delegation;
 pub mod vault_staker_withdrawal_ticket;
 pub mod vault_update_state_tracker;
+
+pub const MAX_FEE_BPS: u16 = 10_000;

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -9,7 +9,7 @@ use jito_vault_sdk::error::VaultError;
 use shank::ShankAccount;
 use solana_program::{account_info::AccountInfo, msg, program_error::ProgramError, pubkey::Pubkey};
 
-use crate::delegation_state::DelegationState;
+use crate::{delegation_state::DelegationState, MAX_FEE_BPS};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct BurnSummary {
@@ -205,10 +205,6 @@ impl Vault {
         self.vault_index.into()
     }
 
-    pub fn set_reward_fee_bps(&mut self, reward_fee_bps: u16) {
-        self.reward_fee_bps = PodU16::from(reward_fee_bps);
-    }
-
     pub fn set_last_fee_change_slot(&mut self, slot: u64) {
         self.last_fee_change_slot = PodU64::from(slot);
     }
@@ -227,10 +223,6 @@ impl Vault {
 
     pub fn tokens_deposited(&self) -> u64 {
         self.tokens_deposited.into()
-    }
-
-    pub fn set_withdrawal_fee_bps(&mut self, withdrawal_fee_bps: u16) {
-        self.withdrawal_fee_bps = PodU16::from(withdrawal_fee_bps);
     }
 
     pub fn increment_tokens_deposited(&mut self, amount: u64) -> Result<(), VaultError> {
@@ -367,10 +359,6 @@ impl Vault {
 
     pub fn set_vrt_enqueued_for_cooldown_amount(&mut self, amount: u64) {
         self.vrt_enqueued_for_cooldown_amount = PodU64::from(amount);
-    }
-
-    pub fn set_deposit_fee_bps(&mut self, deposit_fee_bps: u16) {
-        self.deposit_fee_bps = PodU16::from(deposit_fee_bps);
     }
 
     pub fn set_tokens_deposited(&mut self, tokens_deposited: u64) {
@@ -536,6 +524,131 @@ impl Vault {
                 return Err(VaultError::VaultMintBurnAdminInvalid.into());
             }
         }
+        Ok(())
+    }
+
+    // ------------------------------------------
+    // Fees
+    // ------------------------------------------
+
+    /// Fees can be changed at most one per epoch.
+    #[inline(always)]
+    pub fn check_can_modify_fees(&self, slot: u64, epoch_length: u64) -> Result<(), VaultError> {
+        let current_epoch = slot.checked_div(epoch_length).unwrap();
+        let last_fee_change_epoch = self
+            .last_fee_change_slot()
+            .checked_div(epoch_length)
+            .unwrap();
+
+        if current_epoch <= last_fee_change_epoch {
+            msg!("Fee changes are only allowed once per epoch");
+            return Err(VaultError::VaultFeeChangeTooSoon);
+        }
+
+        Ok(())
+    }
+
+    pub fn set_withdrawal_fee_bps(
+        &mut self,
+        withdrawal_fee_bps: u16,
+        deposit_withdrawal_fee_cap_bps: u16,
+        fee_bump_bps: u16,
+        fee_rate_of_change_bps: u16,
+    ) -> Result<(), VaultError> {
+        if withdrawal_fee_bps > MAX_FEE_BPS {
+            msg!("Withdrawal fee exceeds maximum allowed of {}", MAX_FEE_BPS);
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+        if withdrawal_fee_bps > deposit_withdrawal_fee_cap_bps {
+            msg!(
+                "Withdrawal fee exceeds maximum allowed of {}",
+                deposit_withdrawal_fee_cap_bps
+            );
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+        Self::check_fee_change_ok(
+            self.withdrawal_fee_bps(),
+            withdrawal_fee_bps,
+            deposit_withdrawal_fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps,
+        )?;
+        self.withdrawal_fee_bps = PodU16::from(withdrawal_fee_bps);
+        Ok(())
+    }
+
+    pub fn set_deposit_fee_bps(
+        &mut self,
+        deposit_fee_bps: u16,
+        deposit_withdrawal_fee_cap_bps: u16,
+        fee_bump_bps: u16,
+        fee_rate_of_change_bps: u16,
+    ) -> Result<(), VaultError> {
+        if deposit_fee_bps > MAX_FEE_BPS {
+            msg!("Deposit fee exceeds maximum allowed of {}", MAX_FEE_BPS);
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+        if deposit_fee_bps > deposit_withdrawal_fee_cap_bps {
+            msg!(
+                "Deposit fee exceeds maximum allowed of {}",
+                deposit_withdrawal_fee_cap_bps
+            );
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+
+        Self::check_fee_change_ok(
+            self.deposit_fee_bps(),
+            deposit_fee_bps,
+            deposit_withdrawal_fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps,
+        )?;
+
+        self.deposit_fee_bps = PodU16::from(deposit_fee_bps);
+        Ok(())
+    }
+
+    pub fn set_reward_fee_bps(&mut self, reward_fee_bps: u16) -> Result<(), VaultError> {
+        if reward_fee_bps > MAX_FEE_BPS {
+            msg!("Reward fee exceeds maximum allowed of {}", MAX_FEE_BPS);
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+        self.reward_fee_bps = PodU16::from(reward_fee_bps);
+        Ok(())
+    }
+
+    fn check_fee_change_ok(
+        current_fee_bps: u16,
+        new_fee_bps: u16,
+        fee_cap_bps: u16,
+        fee_bump_bps: u16,
+        fee_rate_of_change_bps: u16,
+    ) -> Result<(), VaultError> {
+        let fee_delta = new_fee_bps.saturating_sub(current_fee_bps);
+        let fee_cap_bps = fee_cap_bps.min(MAX_FEE_BPS);
+
+        if new_fee_bps > fee_cap_bps {
+            msg!("Fee exceeds maximum allowed of {}", fee_cap_bps);
+            return Err(VaultError::VaultFeeCapExceeded);
+        }
+
+        if fee_delta > fee_bump_bps {
+            let deposit_percentage_increase_bps: u64 = (fee_delta as u128)
+                .checked_mul(10000)
+                .and_then(|product| product.checked_div(current_fee_bps as u128))
+                .and_then(|result| result.try_into().ok())
+                .unwrap_or(u64::MAX); // Divide by zero should result in max value
+
+            if deposit_percentage_increase_bps > fee_rate_of_change_bps as u64 {
+                msg!(
+                    "Fee increase exceeds maximum rate of change {} bps or flat bump of {} bps",
+                    fee_rate_of_change_bps,
+                    fee_bump_bps
+                );
+                return Err(VaultError::VaultFeeBumpTooLarge);
+            }
+        }
+
         Ok(())
     }
 
@@ -907,6 +1020,7 @@ mod tests {
     use crate::{
         delegation_state::DelegationState,
         vault::{BurnSummary, MintSummary, Vault},
+        MAX_FEE_BPS,
     };
 
     fn make_test_vault(
@@ -1561,5 +1675,280 @@ mod tests {
         let fee = vault.calculate_rewards_fee(1000).unwrap();
 
         assert_eq!(fee, 1000);
+    }
+
+    #[test]
+    fn test_fee_change_after_two_epochs() {
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
+        vault.last_fee_change_slot = PodU64::from(1);
+        assert_eq!(vault.check_can_modify_fees(200, 100), Ok(()));
+    }
+
+    #[test]
+    fn test_fee_change_within_same_epoch() {
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
+        vault.last_fee_change_slot = PodU64::from(101);
+        assert_eq!(
+            vault.check_can_modify_fees(102, 100),
+            Err(VaultError::VaultFeeChangeTooSoon)
+        );
+    }
+
+    #[test]
+    fn test_fee_change_in_next_epoch() {
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
+        vault.last_fee_change_slot = PodU64::from(1);
+        assert_eq!(vault.check_can_modify_fees(101, 100), Ok(()));
+    }
+
+    #[test]
+    fn test_fee_change_at_epoch_boundary() {
+        let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
+        vault.last_fee_change_slot = PodU64::from(1);
+        assert_eq!(vault.check_can_modify_fees(100, 100), Ok(()));
+    }
+
+    #[test]
+    fn test_fee_increase_within_limits() {
+        let current_fee_bps = 100;
+        let new_fee_bps = 125;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // OK: 25% increase <= 25% limit
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_fee_increase_outside_limits() {
+        let current_fee_bps = 100;
+        let new_fee_bps = 126;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // ERROR: 26% increase > 25% limit
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_fee_increase_inside_bump_limits() {
+        let current_fee_bps = 1;
+        let new_fee_bps = 10;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // OK: Δ <= bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_fee_increase_outside_bump_limits() {
+        let current_fee_bps = 1;
+        let new_fee_bps = 13;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // ERROR: Δ > bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_zero_ok() {
+        let current_fee_bps = 0;
+        let new_fee_bps = 10;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // OK: Δ <= bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_zero_bad() {
+        let current_fee_bps = 0;
+        let new_fee_bps = 11;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // Error: Δ > bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_no_difference() {
+        let current_fee_bps = 100;
+        let new_fee_bps = 100;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // OK: Δ <= bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_decrease() {
+        let current_fee_bps = 100;
+        let new_fee_bps = 0;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        // OK: Δ <= bump
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_max_fee_values() {
+        let max_fee_bps = MAX_FEE_BPS;
+
+        let current_fee_bps = max_fee_bps - 1;
+        let new_fee_bps = max_fee_bps;
+        let fee_cap_bps = max_fee_bps;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_max_decrease() {
+        let current_fee_bps = u16::MAX;
+        let new_fee_bps = 0;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_max_increase() {
+        let current_fee_bps = 0;
+        let new_fee_bps = u16::MAX;
+        let fee_cap_bps = u16::MAX;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_at_cap() {
+        let current_fee_bps = 2999;
+        let new_fee_bps = 3000;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_above_cap() {
+        let current_fee_bps = 2999;
+        let new_fee_bps = 3001;
+        let fee_cap_bps = 3000;
+        let fee_bump_bps = 10;
+        let fee_rate_of_change_bps = 2500;
+
+        assert!(Vault::check_fee_change_ok(
+            current_fee_bps,
+            new_fee_bps,
+            fee_cap_bps,
+            fee_bump_bps,
+            fee_rate_of_change_bps
+        )
+        .is_err());
     }
 }

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -1696,14 +1696,20 @@ mod tests {
     fn test_fee_change_in_next_epoch() {
         let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
         vault.last_fee_change_slot = PodU64::from(1);
-        assert_eq!(vault.check_can_modify_fees(101, 100), Err(VaultError::VaultFeeChangeTooSoon));
+        assert_eq!(
+            vault.check_can_modify_fees(101, 100),
+            Err(VaultError::VaultFeeChangeTooSoon)
+        );
     }
 
     #[test]
     fn test_fee_change_at_epoch_boundary() {
         let mut vault = make_test_vault(0, 0, 0, 0, DelegationState::default());
         vault.last_fee_change_slot = PodU64::from(1);
-        assert_eq!(vault.check_can_modify_fees(100, 100), Err(VaultError::VaultFeeChangeTooSoon));
+        assert_eq!(
+            vault.check_can_modify_fees(100, 100),
+            Err(VaultError::VaultFeeChangeTooSoon)
+        );
     }
 
     #[test]

--- a/vault_program/src/initialize_vault.rs
+++ b/vault_program/src/initialize_vault.rs
@@ -7,7 +7,7 @@ use jito_jsm_core::{
         load_signer, load_system_account, load_system_program, load_token_mint, load_token_program,
     },
 };
-use jito_vault_core::{config::Config, vault::Vault};
+use jito_vault_core::{config::Config, vault::Vault, MAX_FEE_BPS};
 use jito_vault_sdk::error::VaultError;
 use solana_program::{
     account_info::AccountInfo, entrypoint::ProgramResult, msg, program::invoke,
@@ -97,6 +97,7 @@ pub fn process_initialize_vault(
 
         if deposit_fee_bps > config.deposit_withdrawal_fee_cap_bps()
             || withdrawal_fee_bps > config.deposit_withdrawal_fee_cap_bps()
+            || reward_fee_bps > MAX_FEE_BPS
         {
             msg!(
                 "Fee cap exceeds maximum allowed of {}",

--- a/vault_program/src/initialize_vault.rs
+++ b/vault_program/src/initialize_vault.rs
@@ -29,6 +29,9 @@ pub fn process_initialize_vault(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     Config::load(program_id, config, true)?;
+    let mut config_data = config.data.borrow_mut();
+    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+
     load_system_account(vault, true)?;
     load_system_account(vrt_mint, true)?;
     load_signer(vrt_mint, true)?;
@@ -45,6 +48,17 @@ pub fn process_initialize_vault(
     if vault.key.ne(&vault_pubkey) {
         msg!("Vault account is not at the correct PDA");
         return Err(ProgramError::InvalidAccountData);
+    }
+
+    if deposit_fee_bps > config.deposit_withdrawal_fee_cap_bps()
+        || withdrawal_fee_bps > config.deposit_withdrawal_fee_cap_bps()
+        || reward_fee_bps > MAX_FEE_BPS
+    {
+        msg!(
+            "Fee cap exceeds maximum allowed of {}",
+            config.deposit_withdrawal_fee_cap_bps()
+        );
+        return Err(VaultError::VaultFeeCapExceeded.into());
     }
 
     let rent = Rent::get()?;
@@ -75,9 +89,6 @@ pub fn process_initialize_vault(
         )?;
     }
 
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
-
     // Initialize vault
     {
         msg!("Initializing vault at address {}", vault.key);
@@ -94,17 +105,6 @@ pub fn process_initialize_vault(
         let mut vault_data = vault.try_borrow_mut_data()?;
         vault_data[0] = Vault::DISCRIMINATOR;
         let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
-
-        if deposit_fee_bps > config.deposit_withdrawal_fee_cap_bps()
-            || withdrawal_fee_bps > config.deposit_withdrawal_fee_cap_bps()
-            || reward_fee_bps > MAX_FEE_BPS
-        {
-            msg!(
-                "Fee cap exceeds maximum allowed of {}",
-                config.deposit_withdrawal_fee_cap_bps()
-            );
-            return Err(VaultError::VaultFeeCapExceeded.into());
-        }
 
         *vault = Vault::new(
             *vrt_mint.key,

--- a/vault_program/src/initialize_vault.rs
+++ b/vault_program/src/initialize_vault.rs
@@ -95,10 +95,12 @@ pub fn process_initialize_vault(
         vault_data[0] = Vault::DISCRIMINATOR;
         let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
 
-        if deposit_fee_bps > config.fee_cap_bps() || withdrawal_fee_bps > config.fee_cap_bps() {
+        if deposit_fee_bps > config.deposit_withdrawal_fee_cap_bps()
+            || withdrawal_fee_bps > config.deposit_withdrawal_fee_cap_bps()
+        {
             msg!(
                 "Fee cap exceeds maximum allowed of {}",
-                config.fee_cap_bps()
+                config.deposit_withdrawal_fee_cap_bps()
             );
             return Err(VaultError::VaultFeeCapExceeded.into());
         }

--- a/vault_program/src/set_fees.rs
+++ b/vault_program/src/set_fees.rs
@@ -11,6 +11,7 @@ use solana_program::{
 /// Specification:
 /// - The fee can only be changed by the vault fee admin. The vault fee admin must sign the transaction.
 /// - The fees can only be changed at most once per epoch.
+/// - The fees can be changed the epoch after one full epoch has passed since the last fee change.
 /// - The Vault last_fee_change_slot shall be updated to the current slot only if any fees were updated.
 /// - The transaction shall fail if no fees are provided to update.
 /// - The transaction shall fail if any of the fees exceed 10_000 bps.

--- a/vault_program/src/set_fees.rs
+++ b/vault_program/src/set_fees.rs
@@ -1,12 +1,19 @@
 use jito_bytemuck::AccountDeserialize;
 use jito_jsm_core::loader::load_signer;
 use jito_vault_core::{config::Config, vault::Vault};
-use jito_vault_sdk::error::VaultError;
 use solana_program::{
     account_info::AccountInfo, clock::Clock, entrypoint::ProgramResult, msg,
     program_error::ProgramError, pubkey::Pubkey, sysvar::Sysvar,
 };
 
+/// Sets the deposit, withdrawal, and reward fees for the vault.
+///
+/// Specification:
+/// - The fee can only be changed by the vault fee admin. The vault fee admin must sign the transaction.
+/// - The fees can only be changed at most once per epoch.
+/// - The Vault last_fee_change_slot shall be updated to the current slot only if any fees were updated.
+/// - The transaction shall fail if no fees are provided to update.
+/// - The transaction shall fail if any of the fees exceed 10_000 bps.
 pub fn process_set_fees(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -26,14 +33,7 @@ pub fn process_set_fees(
     load_signer(vault_fee_admin, false)?;
 
     vault.check_fee_admin(vault_fee_admin.key)?;
-
-    // Fees changes have a cooldown of 1 full epoch
-    let current_slot = Clock::get()?.slot;
-    check_fee_cooldown_ok(
-        current_slot,
-        vault.last_fee_change_slot(),
-        config.epoch_length(),
-    )?;
+    vault.check_can_modify_fees(Clock::get()?.slot, config.epoch_length())?;
 
     if deposit_fee_bps.is_none() && withdrawal_fee_bps.is_none() && reward_fee_bps.is_none() {
         msg!("No fees provided for update");
@@ -41,394 +41,28 @@ pub fn process_set_fees(
     }
 
     if let Some(deposit_fee_bps) = deposit_fee_bps {
-        check_fee_change_ok(
-            vault.deposit_fee_bps(),
+        vault.set_deposit_fee_bps(
             deposit_fee_bps,
-            config.fee_cap_bps(),
+            config.deposit_withdrawal_fee_cap_bps(),
             config.fee_bump_bps(),
             config.fee_rate_of_change_bps(),
         )?;
-
-        vault.set_deposit_fee_bps(deposit_fee_bps);
     }
 
     if let Some(withdrawal_fee_bps) = withdrawal_fee_bps {
-        check_fee_change_ok(
-            vault.withdrawal_fee_bps(),
+        vault.set_withdrawal_fee_bps(
             withdrawal_fee_bps,
-            config.fee_cap_bps(),
+            config.deposit_withdrawal_fee_cap_bps(),
             config.fee_bump_bps(),
             config.fee_rate_of_change_bps(),
         )?;
-
-        vault.set_withdrawal_fee_bps(withdrawal_fee_bps);
     }
 
     if let Some(reward_fee_bps) = reward_fee_bps {
-        if reward_fee_bps > Config::MAX_BPS {
-            msg!("Epoch fee exceeds maximum allowed of {}", Config::MAX_BPS);
-            return Err(VaultError::VaultFeeCapExceeded.into());
-        }
-
-        vault.set_reward_fee_bps(reward_fee_bps);
+        vault.set_reward_fee_bps(reward_fee_bps)?;
     }
 
-    vault.set_last_fee_change_slot(current_slot);
+    vault.set_last_fee_change_slot(Clock::get()?.slot);
 
     Ok(())
-}
-
-pub fn check_fee_cooldown_ok(
-    current_slot: u64,
-    last_fee_change_slot: u64,
-    epoch_length: u64,
-) -> ProgramResult {
-    let current_epoch = current_slot.checked_div(epoch_length).unwrap();
-    let last_fee_change_epoch = last_fee_change_slot.checked_div(epoch_length).unwrap();
-
-    if current_epoch <= last_fee_change_epoch.checked_add(1).unwrap() {
-        msg!("Fee changes are only allowed once per epoch");
-        return Err(VaultError::VaultFeeChangeTooSoon.into());
-    }
-
-    Ok(())
-}
-
-pub fn check_fee_change_ok(
-    current_fee_bps: u16,
-    new_fee_bps: u16,
-    fee_cap_bps: u16,
-    fee_bump_bps: u16,
-    fee_rate_of_change_bps: u16,
-) -> ProgramResult {
-    let fee_delta = new_fee_bps.saturating_sub(current_fee_bps);
-    let fee_cap_bps = fee_cap_bps.min(Config::MAX_BPS);
-
-    if new_fee_bps > fee_cap_bps {
-        msg!("Fee exceeds maximum allowed of {}", fee_cap_bps);
-        return Err(VaultError::VaultFeeCapExceeded.into());
-    }
-
-    if fee_delta > fee_bump_bps {
-        let deposit_percentage_increase_bps: u64 = (fee_delta as u128)
-            .checked_mul(10000)
-            .and_then(|product| product.checked_div(current_fee_bps as u128))
-            .and_then(|result| result.try_into().ok())
-            .unwrap_or(u64::MAX); // Divide by zero should result in max value
-
-        if deposit_percentage_increase_bps > fee_rate_of_change_bps as u64 {
-            msg!(
-                "Fee increase exceeds maximum rate of change {} bps or flat bump of {} bps",
-                fee_rate_of_change_bps,
-                fee_bump_bps
-            );
-            return Err(VaultError::VaultFeeBumpTooLarge.into());
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn test_fee_change_after_two_epochs() {
-        let current_slot = 1_000_000;
-        let epoch_length = 100_000;
-        let last_fee_change_slot = current_slot - (2 * epoch_length) - 1;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_ok());
-    }
-
-    #[test]
-    fn test_fee_change_within_same_epoch() {
-        let current_slot = 150_000;
-        let epoch_length = 100_000;
-        let last_fee_change_slot = 140_000;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_err());
-    }
-
-    #[test]
-    fn test_fee_change_in_next_epoch() {
-        let current_slot = 110_000;
-        let epoch_length = 100_000;
-        let last_fee_change_slot = 90_000;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_err());
-    }
-
-    #[test]
-    fn test_fee_change_at_epoch_boundary() {
-        let current_slot = 200_000;
-        let epoch_length = 100_000;
-        let last_fee_change_slot = 100_000;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_err());
-    }
-
-    #[test]
-    fn test_fee_change_just_after_epoch_boundary() {
-        let current_slot = 200_001;
-        let epoch_length = 100_000;
-        let last_fee_change_slot = 99_999;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_ok());
-    }
-
-    #[test]
-    fn test_fee_change_with_large_slot_numbers() {
-        let current_slot = 1_000_000_000;
-        let epoch_length = 100_000_000;
-        let last_fee_change_slot = 799_999_999;
-
-        assert!(check_fee_cooldown_ok(current_slot, last_fee_change_slot, epoch_length).is_ok());
-    }
-
-    #[test]
-    fn test_fee_increase_within_limits() {
-        let current_fee_bps = 100;
-        let new_fee_bps = 125;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // OK: 25% increase <= 25% limit
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_fee_increase_outside_limits() {
-        let current_fee_bps = 100;
-        let new_fee_bps = 126;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // ERROR: 26% increase > 25% limit
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_fee_increase_inside_bump_limits() {
-        let current_fee_bps = 1;
-        let new_fee_bps = 10;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // OK: Δ <= bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_fee_increase_outside_bump_limits() {
-        let current_fee_bps = 1;
-        let new_fee_bps = 13;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // ERROR: Δ > bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_zero_ok() {
-        let current_fee_bps = 0;
-        let new_fee_bps = 10;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // OK: Δ <= bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_zero_bad() {
-        let current_fee_bps = 0;
-        let new_fee_bps = 11;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // Error: Δ > bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_no_difference() {
-        let current_fee_bps = 100;
-        let new_fee_bps = 100;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // OK: Δ <= bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_decrease() {
-        let current_fee_bps = 100;
-        let new_fee_bps = 0;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        // OK: Δ <= bump
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_max_fee_values() {
-        let max_fee_bps = Config::MAX_BPS;
-
-        let current_fee_bps = max_fee_bps - 1;
-        let new_fee_bps = max_fee_bps;
-        let fee_cap_bps = max_fee_bps;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_max_decrease() {
-        let current_fee_bps = u16::MAX;
-        let new_fee_bps = 0;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_max_increase() {
-        let current_fee_bps = 0;
-        let new_fee_bps = u16::MAX;
-        let fee_cap_bps = u16::MAX;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_err());
-    }
-
-    #[test]
-    fn test_at_cap() {
-        let current_fee_bps = 2999;
-        let new_fee_bps = 3000;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn test_above_cap() {
-        let current_fee_bps = 2999;
-        let new_fee_bps = 3001;
-        let fee_cap_bps = 3000;
-        let fee_bump_bps = 10;
-        let fee_rate_of_change_bps = 2500;
-
-        assert!(check_fee_change_ok(
-            current_fee_bps,
-            new_fee_bps,
-            fee_cap_bps,
-            fee_bump_bps,
-            fee_rate_of_change_bps
-        )
-        .is_err());
-    }
 }


### PR DESCRIPTION
- Bug: reward_fee_bps wasn't checked on initialization. Add test to ensure that's within bounds.
- Add tests checking any fees above 10k or larger than config.deposit_withdrawal_fee_cap_bps on init fail
- Rename config fee_cap_bps to deposit_withdrawal_fee_cap_bps
- Moves some fee math to the vault