### PR TITLE
Bugfix: Make the vault mutable for vault operator delegation

### DIFF
--- a/clients/js/vault_client/instructions/initializeVaultOperatorDelegation.ts
+++ b/clients/js/vault_client/instructions/initializeVaultOperatorDelegation.ts
@@ -62,7 +62,7 @@ export type InitializeVaultOperatorDelegationInstruction<
         ? ReadonlyAccount<TAccountConfig>
         : TAccountConfig,
       TAccountVault extends string
-        ? ReadonlyAccount<TAccountVault>
+        ? WritableAccount<TAccountVault>
         : TAccountVault,
       TAccountOperator extends string
         ? WritableAccount<TAccountOperator>
@@ -175,7 +175,7 @@ export function getInitializeVaultOperatorDelegationInstruction<
   // Original accounts.
   const originalAccounts = {
     config: { value: input.config ?? null, isWritable: false },
-    vault: { value: input.vault ?? null, isWritable: false },
+    vault: { value: input.vault ?? null, isWritable: true },
     operator: { value: input.operator ?? null, isWritable: true },
     operatorVaultTicket: {
       value: input.operatorVaultTicket ?? null,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_operator_delegation.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_operator_delegation.rs
@@ -39,7 +39,7 @@ impl InitializeVaultOperatorDelegation {
             self.config,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             self.vault, false,
         ));
         accounts.push(solana_program::instruction::AccountMeta::new(
@@ -99,7 +99,7 @@ impl Default for InitializeVaultOperatorDelegationInstructionData {
 /// ### Accounts:
 ///
 ///   0. `[]` config
-///   1. `[]` vault
+///   1. `[writable]` vault
 ///   2. `[writable]` operator
 ///   3. `[]` operator_vault_ticket
 ///   4. `[writable]` vault_operator_delegation
@@ -307,7 +307,7 @@ impl<'a, 'b> InitializeVaultOperatorDelegationCpi<'a, 'b> {
             *self.config.key,
             false,
         ));
-        accounts.push(solana_program::instruction::AccountMeta::new_readonly(
+        accounts.push(solana_program::instruction::AccountMeta::new(
             *self.vault.key,
             false,
         ));
@@ -378,7 +378,7 @@ impl<'a, 'b> InitializeVaultOperatorDelegationCpi<'a, 'b> {
 /// ### Accounts:
 ///
 ///   0. `[]` config
-///   1. `[]` vault
+///   1. `[writable]` vault
 ///   2. `[writable]` operator
 ///   3. `[]` operator_vault_ticket
 ///   4. `[writable]` vault_operator_delegation

--- a/idl/jito_vault.json
+++ b/idl/jito_vault.json
@@ -114,7 +114,7 @@
         },
         {
           "name": "vault",
-          "isMut": false,
+          "isMut": true,
           "isSigner": false
         },
         {

--- a/restaking_program/src/cooldown_ncn_vault_slasher_ticket.rs
+++ b/restaking_program/src/cooldown_ncn_vault_slasher_ticket.rs
@@ -21,8 +21,8 @@ pub fn process_cooldown_ncn_vault_slasher_ticket(
     };
     Config::load(program_id, config, false)?;
     Ncn::load(program_id, ncn, false)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(&config.vault_program, vault, false)?;
     NcnVaultSlasherTicket::load(
         program_id,

--- a/restaking_program/src/cooldown_ncn_vault_ticket.rs
+++ b/restaking_program/src/cooldown_ncn_vault_ticket.rs
@@ -30,8 +30,8 @@ pub fn process_cooldown_ncn_vault_ticket(
     }
 
     // The NcnVaultTicket shall be active before it can be cooled down
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     let mut ncn_vault_ticket_data = ncn_vault_ticket.data.borrow_mut();
     let ncn_vault_ticket =
         NcnVaultTicket::try_from_slice_unchecked_mut(&mut ncn_vault_ticket_data)?;

--- a/restaking_program/src/cooldown_operator_vault_ticket.rs
+++ b/restaking_program/src/cooldown_operator_vault_ticket.rs
@@ -21,8 +21,8 @@ pub fn process_cooldown_operator_vault_ticket(
 
     Config::load(program_id, config, false)?;
     Operator::load(program_id, operator, false)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(&config.vault_program, vault, false)?;
     OperatorVaultTicket::load(program_id, operator_vault_ticket, operator, vault, true)?;
     load_signer(operator_vault_admin, false)?;

--- a/restaking_program/src/initialize_ncn_vault_slasher_ticket.rs
+++ b/restaking_program/src/initialize_ncn_vault_slasher_ticket.rs
@@ -29,8 +29,8 @@ pub fn process_initialize_ncn_vault_slasher_ticket(
 
     Config::load(program_id, config, false)?;
     Ncn::load(program_id, ncn_info, true)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(&config.vault_program, vault, false)?;
     NcnVaultTicket::load(program_id, ncn_vault_ticket, ncn_info, vault, false)?;
     load_system_account(ncn_vault_slasher_ticket, true)?;

--- a/restaking_program/src/initialize_operator_vault_ticket.rs
+++ b/restaking_program/src/initialize_operator_vault_ticket.rs
@@ -31,8 +31,8 @@ pub fn process_initialize_operator_vault_ticket(
 
     Config::load(program_id, config, false)?;
     Operator::load(program_id, operator_info, true)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(&config.vault_program, vault, false)?;
     load_system_account(operator_vault_ticket_account, true)?;
     load_signer(operator_vault_admin, false)?;

--- a/restaking_program/src/ncn_cooldown_operator.rs
+++ b/restaking_program/src/ncn_cooldown_operator.rs
@@ -35,8 +35,8 @@ pub fn process_ncn_cooldown_operator(
     }
 
     // The NcnOperatorTicket shall be active before it can be cooled down
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     let mut ncn_operator_state_data = ncn_operator_state.data.borrow_mut();
     let ncn_operator_ticket =
         NcnOperatorState::try_from_slice_unchecked_mut(&mut ncn_operator_state_data)?;

--- a/restaking_program/src/operator_cooldown_ncn.rs
+++ b/restaking_program/src/operator_cooldown_ncn.rs
@@ -33,8 +33,8 @@ pub fn process_operator_cooldown_ncn(
     }
 
     // The OperatorNcnTicket shall be active before it can be cooled down
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     let mut ncn_operator_state_data = ncn_operator_state.data.borrow_mut();
     let ncn_operator_state =
         NcnOperatorState::try_from_slice_unchecked_mut(&mut ncn_operator_state_data)?;

--- a/vault_program/src/initialize_vault_ncn_slasher_ticket.rs
+++ b/vault_program/src/initialize_vault_ncn_slasher_ticket.rs
@@ -26,8 +26,8 @@ pub fn process_initialize_vault_ncn_slasher_ticket(
     };
 
     Config::load(program_id, config, false)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(program_id, vault_info, false)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;

--- a/vault_program/src/initialize_vault_operator_delegation.rs
+++ b/vault_program/src/initialize_vault_operator_delegation.rs
@@ -28,7 +28,7 @@ pub fn process_initialize_vault_operator_delegation(
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();
     let config = Config::try_from_slice_unchecked(&config_data)?;
-    Vault::load(program_id, vault_info, false)?;
+    Vault::load(program_id, vault_info, true)?;
     let mut vault_data = vault_info.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;
     Operator::load(&config.restaking_program, operator, false)?;

--- a/vault_program/src/set_fees.rs
+++ b/vault_program/src/set_fees.rs
@@ -26,8 +26,8 @@ pub fn process_set_fees(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
     Config::load(program_id, config, false)?;
-    let mut config_data = config.data.borrow_mut();
-    let config = Config::try_from_slice_unchecked_mut(&mut config_data)?;
+    let config_data = config.data.borrow();
+    let config = Config::try_from_slice_unchecked(&config_data)?;
     Vault::load(program_id, vault, true)?;
     let mut vault_data = vault.data.borrow_mut();
     let vault = Vault::try_from_slice_unchecked_mut(&mut vault_data)?;

--- a/vault_sdk/src/instruction.rs
+++ b/vault_sdk/src/instruction.rs
@@ -32,7 +32,7 @@ pub enum VaultInstruction {
 
     /// Vault adds support for an operator
     #[account(0, name = "config")]
-    #[account(1, name = "vault")]
+    #[account(1, writable, name = "vault")]
     #[account(2, writable, name = "operator")]
     #[account(3, name = "operator_vault_ticket")]
     #[account(4, writable, name = "vault_operator_delegation")]


### PR DESCRIPTION
Fixes the following bugs:
- Require the vault is writable during initializing the VaultOperatorDelegation ticket
- Update the shank file -> updates clients
- Don't borrow structs as mutable unless required