### PR TITLE
Restaking: process_set_node_operator_admin and process_set_operator_secondary_admin should set expect_writable for the operator account

### DIFF
--- a/integration_tests/tests/fixtures/restaking_client.rs
+++ b/integration_tests/tests/fixtures/restaking_client.rs
@@ -6,13 +6,14 @@ use jito_restaking_core::{
 };
 use jito_restaking_sdk::{
     error::RestakingError,
+    instruction::OperatorAdminRole,
     sdk::{
         cooldown_ncn_vault_ticket, initialize_config, initialize_ncn,
         initialize_ncn_operator_state, initialize_ncn_vault_slasher_ticket,
         initialize_ncn_vault_ticket, initialize_operator, initialize_operator_vault_ticket,
         ncn_cooldown_operator, ncn_set_admin, ncn_warmup_operator, operator_cooldown_ncn,
-        operator_set_admin, operator_warmup_ncn, warmup_ncn_vault_slasher_ticket,
-        warmup_ncn_vault_ticket, warmup_operator_vault_ticket,
+        operator_set_admin, operator_set_secondary_admin, operator_warmup_ncn,
+        warmup_ncn_vault_slasher_ticket, warmup_ncn_vault_ticket, warmup_operator_vault_ticket,
     },
 };
 use solana_program::{
@@ -857,6 +858,30 @@ impl RestakingProgramClient {
             )],
             Some(&old_admin.pubkey()),
             &[old_admin, new_admin],
+            blockhash,
+        ))
+        .await
+    }
+
+    pub async fn operator_set_secondary_admin(
+        &mut self,
+        operator: &Pubkey,
+        old_admin: &Keypair,
+        new_admin: &Keypair,
+        operator_admin_role: OperatorAdminRole,
+    ) -> TestResult<()> {
+        let blockhash = self.banks_client.get_latest_blockhash().await?;
+
+        self.process_transaction(&Transaction::new_signed_with_payer(
+            &[operator_set_secondary_admin(
+                &jito_restaking_program::id(),
+                operator,
+                &old_admin.pubkey(),
+                &new_admin.pubkey(),
+                operator_admin_role,
+            )],
+            Some(&old_admin.pubkey()),
+            &[old_admin],
             blockhash,
         ))
         .await

--- a/integration_tests/tests/restaking/mod.rs
+++ b/integration_tests/tests/restaking/mod.rs
@@ -10,4 +10,5 @@ mod ncn_set_admin;
 mod ncn_warmup_operator;
 mod operator_cooldown_ncn;
 mod operator_set_admin;
+mod operator_set_secondary_admin;
 mod operator_warmup_ncn;

--- a/integration_tests/tests/restaking/operator_set_secondary_admin.rs
+++ b/integration_tests/tests/restaking/operator_set_secondary_admin.rs
@@ -1,0 +1,161 @@
+#[cfg(test)]
+mod tests {
+    use jito_restaking_sdk::{error::RestakingError, instruction::OperatorAdminRole};
+    use solana_sdk::{signature::Keypair, signer::Signer};
+
+    use crate::fixtures::{
+        fixture::TestBuilder,
+        restaking_client::{assert_restaking_error, OperatorRoot, RestakingProgramClient},
+    };
+
+    async fn setup() -> (RestakingProgramClient, OperatorRoot) {
+        let fixture = TestBuilder::new().await;
+        let mut restaking_program_client = fixture.restaking_program_client();
+
+        restaking_program_client
+            .do_initialize_config()
+            .await
+            .unwrap();
+
+        let _ncn_root = restaking_program_client.do_initialize_ncn().await.unwrap();
+        let operator_root = restaking_program_client
+            .do_initialize_operator()
+            .await
+            .unwrap();
+
+        (restaking_program_client, operator_root)
+    }
+
+    #[tokio::test]
+    async fn test_operator_set_secondary_admin_with_bad_admin() {
+        let (mut restaking_program_client, operator_root) = setup().await;
+
+        let bad_admin = Keypair::new();
+        restaking_program_client
+            ._airdrop(&bad_admin.pubkey(), 10.0)
+            .await
+            .unwrap();
+
+        let new_admin = Keypair::new();
+        let response = restaking_program_client
+            .operator_set_secondary_admin(
+                &operator_root.operator_pubkey,
+                &bad_admin,
+                &new_admin,
+                OperatorAdminRole::NcnAdmin,
+            )
+            .await;
+
+        assert_restaking_error(response, RestakingError::OperatorAdminInvalid);
+    }
+
+    #[tokio::test]
+    async fn test_operator_set_secondary_admin() {
+        let (mut restaking_program_client, operator_root) = setup().await;
+
+        {
+            // Ncn Admin
+            let new_admin = Keypair::new();
+            restaking_program_client
+                .operator_set_secondary_admin(
+                    &operator_root.operator_pubkey,
+                    &operator_root.operator_admin,
+                    &new_admin,
+                    OperatorAdminRole::NcnAdmin,
+                )
+                .await
+                .unwrap();
+
+            let operator = restaking_program_client
+                .get_operator(&operator_root.operator_pubkey)
+                .await
+                .unwrap();
+
+            assert_eq!(operator.ncn_admin, new_admin.pubkey());
+        }
+
+        {
+            // Vault Admin
+            let new_admin = Keypair::new();
+            restaking_program_client
+                .operator_set_secondary_admin(
+                    &operator_root.operator_pubkey,
+                    &operator_root.operator_admin,
+                    &new_admin,
+                    OperatorAdminRole::VaultAdmin,
+                )
+                .await
+                .unwrap();
+
+            let operator = restaking_program_client
+                .get_operator(&operator_root.operator_pubkey)
+                .await
+                .unwrap();
+
+            assert_eq!(operator.vault_admin, new_admin.pubkey());
+        }
+
+        {
+            // Voter Admin
+            let new_admin = Keypair::new();
+            restaking_program_client
+                .operator_set_secondary_admin(
+                    &operator_root.operator_pubkey,
+                    &operator_root.operator_admin,
+                    &new_admin,
+                    OperatorAdminRole::VoterAdmin,
+                )
+                .await
+                .unwrap();
+
+            let operator = restaking_program_client
+                .get_operator(&operator_root.operator_pubkey)
+                .await
+                .unwrap();
+
+            assert_eq!(operator.voter, new_admin.pubkey());
+        }
+
+        {
+            // Withdraw Admin
+            let new_admin = Keypair::new();
+            restaking_program_client
+                .operator_set_secondary_admin(
+                    &operator_root.operator_pubkey,
+                    &operator_root.operator_admin,
+                    &new_admin,
+                    OperatorAdminRole::WithdrawAdmin,
+                )
+                .await
+                .unwrap();
+
+            let operator = restaking_program_client
+                .get_operator(&operator_root.operator_pubkey)
+                .await
+                .unwrap();
+
+            assert_eq!(operator.withdrawal_admin, new_admin.pubkey());
+        }
+
+        {
+            // Withdraw Wallet
+            let new_admin = Keypair::new();
+            restaking_program_client
+                .operator_set_secondary_admin(
+                    &operator_root.operator_pubkey,
+                    &operator_root.operator_admin,
+                    &new_admin,
+                    OperatorAdminRole::WithdrawWallet,
+                )
+                .await
+                .unwrap();
+
+            let operator = restaking_program_client
+                .get_operator(&operator_root.operator_pubkey)
+                .await
+                .unwrap();
+
+            assert_eq!(operator.withdrawal_fee_wallet, new_admin.pubkey());
+        }
+    }
+}

--- a/restaking_program/src/operator_set_admin.rs
+++ b/restaking_program/src/operator_set_admin.rs
@@ -19,7 +19,7 @@ pub fn process_set_node_operator_admin(
         return Err(ProgramError::NotEnoughAccountKeys);
     };
 
-    Operator::load(program_id, operator, false)?;
+    Operator::load(program_id, operator, true)?;
     load_signer(old_admin, false)?;
     load_signer(new_admin, false)?;
 

--- a/restaking_program/src/operator_set_secondary_admin.rs
+++ b/restaking_program/src/operator_set_secondary_admin.rs
@@ -19,7 +19,7 @@ pub fn process_set_operator_secondary_admin(
     let [operator, admin, new_admin] = accounts else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
-    Operator::load(program_id, operator, false)?;
+    Operator::load(program_id, operator, true)?;
     load_signer(admin, false)?;
 
     // The Operator admin shall be the signer of the transaction

--- a/restaking_sdk/src/sdk.rs
+++ b/restaking_sdk/src/sdk.rs
@@ -294,13 +294,13 @@ pub fn operator_set_secondary_admin(
     program_id: &Pubkey,
     operator: &Pubkey,
     admin: &Pubkey,
-    voter: &Pubkey,
+    new_admin: &Pubkey,
     operator_admin_role: OperatorAdminRole,
 ) -> Instruction {
     let accounts = vec![
         AccountMeta::new(*operator, false),
         AccountMeta::new_readonly(*admin, true),
-        AccountMeta::new_readonly(*voter, false),
+        AccountMeta::new_readonly(*new_admin, false),
     ];
     Instruction {
         program_id: *program_id,


### PR DESCRIPTION
#### Motivation
- Fixes #104 

#### Solution
- Changed `false` to `true` when load Operator.
- Add integration tests for `process_set_operator_secondary_admin` ix