### PR TITLE
NIT: Upgrade kinobi to fix typo

### DIFF
--- a/clients/js/restaking_client/instructions/cooldownNcnVaultSlasherTicket.ts
+++ b/clients/js/restaking_client/instructions/cooldownNcnVaultSlasherTicket.ts
@@ -123,6 +123,7 @@ export function getCooldownNcnVaultSlasherTicketInstruction<
   TAccountSlasher extends string,
   TAccountNcnVaultSlasherTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: CooldownNcnVaultSlasherTicketInput<
     TAccountConfig,
@@ -131,9 +132,10 @@ export function getCooldownNcnVaultSlasherTicketInstruction<
     TAccountSlasher,
     TAccountNcnVaultSlasherTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownNcnVaultSlasherTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -142,7 +144,8 @@ export function getCooldownNcnVaultSlasherTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -174,7 +177,7 @@ export function getCooldownNcnVaultSlasherTicketInstruction<
     programAddress,
     data: getCooldownNcnVaultSlasherTicketInstructionDataEncoder().encode({}),
   } as CooldownNcnVaultSlasherTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/cooldownNcnVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/cooldownNcnVaultTicket.ts
@@ -114,6 +114,7 @@ export function getCooldownNcnVaultTicketInstruction<
   TAccountVault extends string,
   TAccountNcnVaultTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: CooldownNcnVaultTicketInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getCooldownNcnVaultTicketInstruction<
     TAccountVault,
     TAccountNcnVaultTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownNcnVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -131,7 +133,8 @@ export function getCooldownNcnVaultTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +161,7 @@ export function getCooldownNcnVaultTicketInstruction<
     programAddress,
     data: getCooldownNcnVaultTicketInstructionDataEncoder().encode({}),
   } as CooldownNcnVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/cooldownOperatorVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/cooldownOperatorVaultTicket.ts
@@ -118,6 +118,7 @@ export function getCooldownOperatorVaultTicketInstruction<
   TAccountVault extends string,
   TAccountOperatorVaultTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: CooldownOperatorVaultTicketInput<
     TAccountConfig,
@@ -125,9 +126,10 @@ export function getCooldownOperatorVaultTicketInstruction<
     TAccountVault,
     TAccountOperatorVaultTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownOperatorVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountOperator,
   TAccountVault,
@@ -135,7 +137,8 @@ export function getCooldownOperatorVaultTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -165,7 +168,7 @@ export function getCooldownOperatorVaultTicketInstruction<
     programAddress,
     data: getCooldownOperatorVaultTicketInstructionDataEncoder().encode({}),
   } as CooldownOperatorVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountOperator,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/initializeConfig.ts
+++ b/clients/js/restaking_client/instructions/initializeConfig.ts
@@ -108,22 +108,25 @@ export function getInitializeConfigInstruction<
   TAccountAdmin extends string,
   TAccountVaultProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeConfigInput<
     TAccountConfig,
     TAccountAdmin,
     TAccountVaultProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeConfigInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountAdmin,
   TAccountVaultProgram,
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -154,7 +157,7 @@ export function getInitializeConfigInstruction<
     programAddress,
     data: getInitializeConfigInstructionDataEncoder().encode({}),
   } as InitializeConfigInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountAdmin,
     TAccountVaultProgram,

--- a/clients/js/restaking_client/instructions/initializeNcn.ts
+++ b/clients/js/restaking_client/instructions/initializeNcn.ts
@@ -114,6 +114,7 @@ export function getInitializeNcnInstruction<
   TAccountAdmin extends string,
   TAccountBase extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeNcnInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getInitializeNcnInstruction<
     TAccountAdmin,
     TAccountBase,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeNcnInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountAdmin,
@@ -131,7 +133,8 @@ export function getInitializeNcnInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -164,7 +167,7 @@ export function getInitializeNcnInstruction<
     programAddress,
     data: getInitializeNcnInstructionDataEncoder().encode({}),
   } as InitializeNcnInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountAdmin,

--- a/clients/js/restaking_client/instructions/initializeNcnOperatorState.ts
+++ b/clients/js/restaking_client/instructions/initializeNcnOperatorState.ts
@@ -134,6 +134,7 @@ export function getInitializeNcnOperatorStateInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeNcnOperatorStateInput<
     TAccountConfig,
@@ -143,9 +144,10 @@ export function getInitializeNcnOperatorStateInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeNcnOperatorStateInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountOperator,
@@ -155,7 +157,8 @@ export function getInitializeNcnOperatorStateInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -195,7 +198,7 @@ export function getInitializeNcnOperatorStateInstruction<
     programAddress,
     data: getInitializeNcnOperatorStateInstructionDataEncoder().encode({}),
   } as InitializeNcnOperatorStateInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountOperator,

--- a/clients/js/restaking_client/instructions/initializeNcnVaultSlasherTicket.ts
+++ b/clients/js/restaking_client/instructions/initializeNcnVaultSlasherTicket.ts
@@ -162,6 +162,7 @@ export function getInitializeNcnVaultSlasherTicketInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeNcnVaultSlasherTicketInput<
     TAccountConfig,
@@ -173,9 +174,10 @@ export function getInitializeNcnVaultSlasherTicketInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeNcnVaultSlasherTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -187,7 +189,8 @@ export function getInitializeNcnVaultSlasherTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -236,7 +239,7 @@ export function getInitializeNcnVaultSlasherTicketInstruction<
       args as InitializeNcnVaultSlasherTicketInstructionDataArgs
     ),
   } as InitializeNcnVaultSlasherTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/initializeNcnVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/initializeNcnVaultTicket.ts
@@ -132,6 +132,7 @@ export function getInitializeNcnVaultTicketInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeNcnVaultTicketInput<
     TAccountConfig,
@@ -141,9 +142,10 @@ export function getInitializeNcnVaultTicketInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeNcnVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -153,7 +155,8 @@ export function getInitializeNcnVaultTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -190,7 +193,7 @@ export function getInitializeNcnVaultTicketInstruction<
     programAddress,
     data: getInitializeNcnVaultTicketInstructionDataEncoder().encode({}),
   } as InitializeNcnVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/initializeOperator.ts
+++ b/clients/js/restaking_client/instructions/initializeOperator.ts
@@ -128,6 +128,7 @@ export function getInitializeOperatorInstruction<
   TAccountAdmin extends string,
   TAccountBase extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeOperatorInput<
     TAccountConfig,
@@ -135,9 +136,10 @@ export function getInitializeOperatorInstruction<
     TAccountAdmin,
     TAccountBase,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeOperatorInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountOperator,
   TAccountAdmin,
@@ -145,7 +147,8 @@ export function getInitializeOperatorInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -183,7 +186,7 @@ export function getInitializeOperatorInstruction<
       args as InitializeOperatorInstructionDataArgs
     ),
   } as InitializeOperatorInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountOperator,
     TAccountAdmin,

--- a/clients/js/restaking_client/instructions/initializeOperatorVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/initializeOperatorVaultTicket.ts
@@ -136,6 +136,7 @@ export function getInitializeOperatorVaultTicketInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: InitializeOperatorVaultTicketInput<
     TAccountConfig,
@@ -145,9 +146,10 @@ export function getInitializeOperatorVaultTicketInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeOperatorVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountOperator,
   TAccountVault,
@@ -157,7 +159,8 @@ export function getInitializeOperatorVaultTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -197,7 +200,7 @@ export function getInitializeOperatorVaultTicketInstruction<
     programAddress,
     data: getInitializeOperatorVaultTicketInstructionDataEncoder().encode({}),
   } as InitializeOperatorVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountOperator,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/ncnCooldownOperator.ts
+++ b/clients/js/restaking_client/instructions/ncnCooldownOperator.ts
@@ -114,6 +114,7 @@ export function getNcnCooldownOperatorInstruction<
   TAccountOperator extends string,
   TAccountNcnOperatorState extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: NcnCooldownOperatorInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getNcnCooldownOperatorInstruction<
     TAccountOperator,
     TAccountNcnOperatorState,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): NcnCooldownOperatorInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountOperator,
@@ -131,7 +133,8 @@ export function getNcnCooldownOperatorInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -161,7 +164,7 @@ export function getNcnCooldownOperatorInstruction<
     programAddress,
     data: getNcnCooldownOperatorInstructionDataEncoder().encode({}),
   } as NcnCooldownOperatorInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountOperator,

--- a/clients/js/restaking_client/instructions/ncnDelegateTokenAccount.ts
+++ b/clients/js/restaking_client/instructions/ncnDelegateTokenAccount.ts
@@ -123,6 +123,7 @@ export function getNcnDelegateTokenAccountInstruction<
   TAccountTokenAccount extends string,
   TAccountDelegate extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: NcnDelegateTokenAccountInput<
     TAccountNcn,
@@ -131,9 +132,10 @@ export function getNcnDelegateTokenAccountInstruction<
     TAccountTokenAccount,
     TAccountDelegate,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): NcnDelegateTokenAccountInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNcn,
   TAccountDelegateAdmin,
   TAccountTokenMint,
@@ -142,7 +144,8 @@ export function getNcnDelegateTokenAccountInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -177,7 +180,7 @@ export function getNcnDelegateTokenAccountInstruction<
     programAddress,
     data: getNcnDelegateTokenAccountInstructionDataEncoder().encode({}),
   } as NcnDelegateTokenAccountInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNcn,
     TAccountDelegateAdmin,
     TAccountTokenMint,

--- a/clients/js/restaking_client/instructions/ncnSetAdmin.ts
+++ b/clients/js/restaking_client/instructions/ncnSetAdmin.ts
@@ -97,16 +97,19 @@ export function getNcnSetAdminInstruction<
   TAccountNcn extends string,
   TAccountOldAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
-  input: NcnSetAdminInput<TAccountNcn, TAccountOldAdmin, TAccountNewAdmin>
+  input: NcnSetAdminInput<TAccountNcn, TAccountOldAdmin, TAccountNewAdmin>,
+  config?: { programAddress?: TProgramAddress }
 ): NcnSetAdminInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNcn,
   TAccountOldAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -129,7 +132,7 @@ export function getNcnSetAdminInstruction<
     programAddress,
     data: getNcnSetAdminInstructionDataEncoder().encode({}),
   } as NcnSetAdminInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNcn,
     TAccountOldAdmin,
     TAccountNewAdmin

--- a/clients/js/restaking_client/instructions/ncnSetSecondaryAdmin.ts
+++ b/clients/js/restaking_client/instructions/ncnSetSecondaryAdmin.ts
@@ -118,16 +118,23 @@ export function getNcnSetSecondaryAdminInstruction<
   TAccountNcn extends string,
   TAccountAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
-  input: NcnSetSecondaryAdminInput<TAccountNcn, TAccountAdmin, TAccountNewAdmin>
+  input: NcnSetSecondaryAdminInput<
+    TAccountNcn,
+    TAccountAdmin,
+    TAccountNewAdmin
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): NcnSetSecondaryAdminInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountNcn,
   TAccountAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -155,7 +162,7 @@ export function getNcnSetSecondaryAdminInstruction<
       args as NcnSetSecondaryAdminInstructionDataArgs
     ),
   } as NcnSetSecondaryAdminInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountNcn,
     TAccountAdmin,
     TAccountNewAdmin

--- a/clients/js/restaking_client/instructions/ncnWarmupOperator.ts
+++ b/clients/js/restaking_client/instructions/ncnWarmupOperator.ts
@@ -111,6 +111,7 @@ export function getNcnWarmupOperatorInstruction<
   TAccountOperator extends string,
   TAccountNcnOperatorState extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: NcnWarmupOperatorInput<
     TAccountConfig,
@@ -118,9 +119,10 @@ export function getNcnWarmupOperatorInstruction<
     TAccountOperator,
     TAccountNcnOperatorState,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): NcnWarmupOperatorInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountOperator,
@@ -128,7 +130,8 @@ export function getNcnWarmupOperatorInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +161,7 @@ export function getNcnWarmupOperatorInstruction<
     programAddress,
     data: getNcnWarmupOperatorInstructionDataEncoder().encode({}),
   } as NcnWarmupOperatorInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountOperator,

--- a/clients/js/restaking_client/instructions/operatorCooldownNcn.ts
+++ b/clients/js/restaking_client/instructions/operatorCooldownNcn.ts
@@ -114,6 +114,7 @@ export function getOperatorCooldownNcnInstruction<
   TAccountOperator extends string,
   TAccountNcnOperatorState extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: OperatorCooldownNcnInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getOperatorCooldownNcnInstruction<
     TAccountOperator,
     TAccountNcnOperatorState,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorCooldownNcnInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountOperator,
@@ -131,7 +133,8 @@ export function getOperatorCooldownNcnInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -161,7 +164,7 @@ export function getOperatorCooldownNcnInstruction<
     programAddress,
     data: getOperatorCooldownNcnInstructionDataEncoder().encode({}),
   } as OperatorCooldownNcnInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountOperator,

--- a/clients/js/restaking_client/instructions/operatorDelegateTokenAccount.ts
+++ b/clients/js/restaking_client/instructions/operatorDelegateTokenAccount.ts
@@ -127,6 +127,7 @@ export function getOperatorDelegateTokenAccountInstruction<
   TAccountTokenAccount extends string,
   TAccountDelegate extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: OperatorDelegateTokenAccountInput<
     TAccountOperator,
@@ -135,9 +136,10 @@ export function getOperatorDelegateTokenAccountInstruction<
     TAccountTokenAccount,
     TAccountDelegate,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorDelegateTokenAccountInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountOperator,
   TAccountDelegateAdmin,
   TAccountTokenMint,
@@ -146,7 +148,8 @@ export function getOperatorDelegateTokenAccountInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -181,7 +184,7 @@ export function getOperatorDelegateTokenAccountInstruction<
     programAddress,
     data: getOperatorDelegateTokenAccountInstructionDataEncoder().encode({}),
   } as OperatorDelegateTokenAccountInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountOperator,
     TAccountDelegateAdmin,
     TAccountTokenMint,

--- a/clients/js/restaking_client/instructions/operatorSetAdmin.ts
+++ b/clients/js/restaking_client/instructions/operatorSetAdmin.ts
@@ -99,20 +99,23 @@ export function getOperatorSetAdminInstruction<
   TAccountOperator extends string,
   TAccountOldAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: OperatorSetAdminInput<
     TAccountOperator,
     TAccountOldAdmin,
     TAccountNewAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorSetAdminInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountOperator,
   TAccountOldAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -135,7 +138,7 @@ export function getOperatorSetAdminInstruction<
     programAddress,
     data: getOperatorSetAdminInstructionDataEncoder().encode({}),
   } as OperatorSetAdminInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountOperator,
     TAccountOldAdmin,
     TAccountNewAdmin

--- a/clients/js/restaking_client/instructions/operatorSetFee.ts
+++ b/clients/js/restaking_client/instructions/operatorSetFee.ts
@@ -111,16 +111,19 @@ export function getOperatorSetFeeInstruction<
   TAccountConfig extends string,
   TAccountOperator extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
-  input: OperatorSetFeeInput<TAccountConfig, TAccountOperator, TAccountAdmin>
+  input: OperatorSetFeeInput<TAccountConfig, TAccountOperator, TAccountAdmin>,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorSetFeeInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountOperator,
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -148,7 +151,7 @@ export function getOperatorSetFeeInstruction<
       args as OperatorSetFeeInstructionDataArgs
     ),
   } as OperatorSetFeeInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountOperator,
     TAccountAdmin

--- a/clients/js/restaking_client/instructions/operatorSetSecondaryAdmin.ts
+++ b/clients/js/restaking_client/instructions/operatorSetSecondaryAdmin.ts
@@ -120,20 +120,23 @@ export function getOperatorSetSecondaryAdminInstruction<
   TAccountOperator extends string,
   TAccountAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: OperatorSetSecondaryAdminInput<
     TAccountOperator,
     TAccountAdmin,
     TAccountNewAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorSetSecondaryAdminInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountOperator,
   TAccountAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -161,7 +164,7 @@ export function getOperatorSetSecondaryAdminInstruction<
       args as OperatorSetSecondaryAdminInstructionDataArgs
     ),
   } as OperatorSetSecondaryAdminInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountOperator,
     TAccountAdmin,
     TAccountNewAdmin

--- a/clients/js/restaking_client/instructions/operatorWarmupNcn.ts
+++ b/clients/js/restaking_client/instructions/operatorWarmupNcn.ts
@@ -111,6 +111,7 @@ export function getOperatorWarmupNcnInstruction<
   TAccountOperator extends string,
   TAccountNcnOperatorState extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: OperatorWarmupNcnInput<
     TAccountConfig,
@@ -118,9 +119,10 @@ export function getOperatorWarmupNcnInstruction<
     TAccountOperator,
     TAccountNcnOperatorState,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): OperatorWarmupNcnInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountOperator,
@@ -128,7 +130,8 @@ export function getOperatorWarmupNcnInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +161,7 @@ export function getOperatorWarmupNcnInstruction<
     programAddress,
     data: getOperatorWarmupNcnInstructionDataEncoder().encode({}),
   } as OperatorWarmupNcnInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountOperator,

--- a/clients/js/restaking_client/instructions/warmupNcnVaultSlasherTicket.ts
+++ b/clients/js/restaking_client/instructions/warmupNcnVaultSlasherTicket.ts
@@ -130,6 +130,7 @@ export function getWarmupNcnVaultSlasherTicketInstruction<
   TAccountNcnVaultTicket extends string,
   TAccountNcnVaultSlasherTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: WarmupNcnVaultSlasherTicketInput<
     TAccountConfig,
@@ -139,9 +140,10 @@ export function getWarmupNcnVaultSlasherTicketInstruction<
     TAccountNcnVaultTicket,
     TAccountNcnVaultSlasherTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WarmupNcnVaultSlasherTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -151,7 +153,8 @@ export function getWarmupNcnVaultSlasherTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -185,7 +188,7 @@ export function getWarmupNcnVaultSlasherTicketInstruction<
     programAddress,
     data: getWarmupNcnVaultSlasherTicketInstructionDataEncoder().encode({}),
   } as WarmupNcnVaultSlasherTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/warmupNcnVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/warmupNcnVaultTicket.ts
@@ -114,6 +114,7 @@ export function getWarmupNcnVaultTicketInstruction<
   TAccountVault extends string,
   TAccountNcnVaultTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: WarmupNcnVaultTicketInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getWarmupNcnVaultTicketInstruction<
     TAccountVault,
     TAccountNcnVaultTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WarmupNcnVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountNcn,
   TAccountVault,
@@ -131,7 +133,8 @@ export function getWarmupNcnVaultTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +161,7 @@ export function getWarmupNcnVaultTicketInstruction<
     programAddress,
     data: getWarmupNcnVaultTicketInstructionDataEncoder().encode({}),
   } as WarmupNcnVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountNcn,
     TAccountVault,

--- a/clients/js/restaking_client/instructions/warmupOperatorVaultTicket.ts
+++ b/clients/js/restaking_client/instructions/warmupOperatorVaultTicket.ts
@@ -118,6 +118,7 @@ export function getWarmupOperatorVaultTicketInstruction<
   TAccountVault extends string,
   TAccountOperatorVaultTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_RESTAKING_PROGRAM_ADDRESS,
 >(
   input: WarmupOperatorVaultTicketInput<
     TAccountConfig,
@@ -125,9 +126,10 @@ export function getWarmupOperatorVaultTicketInstruction<
     TAccountVault,
     TAccountOperatorVaultTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WarmupOperatorVaultTicketInstruction<
-  typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountOperator,
   TAccountVault,
@@ -135,7 +137,8 @@ export function getWarmupOperatorVaultTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_RESTAKING_PROGRAM_ADDRESS;
+  const programAddress =
+    config?.programAddress ?? JITO_RESTAKING_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -165,7 +168,7 @@ export function getWarmupOperatorVaultTicketInstruction<
     programAddress,
     data: getWarmupOperatorVaultTicketInstructionDataEncoder().encode({}),
   } as WarmupOperatorVaultTicketInstruction<
-    typeof JITO_RESTAKING_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountOperator,
     TAccountVault,

--- a/clients/js/vault_client/instructions/addDelegation.ts
+++ b/clients/js/vault_client/instructions/addDelegation.ts
@@ -127,6 +127,7 @@ export function getAddDelegationInstruction<
   TAccountOperator extends string,
   TAccountVaultOperatorDelegation extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: AddDelegationInput<
     TAccountConfig,
@@ -134,9 +135,10 @@ export function getAddDelegationInstruction<
     TAccountOperator,
     TAccountVaultOperatorDelegation,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): AddDelegationInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountOperator,
@@ -144,7 +146,7 @@ export function getAddDelegationInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -179,7 +181,7 @@ export function getAddDelegationInstruction<
       args as AddDelegationInstructionDataArgs
     ),
   } as AddDelegationInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountOperator,

--- a/clients/js/vault_client/instructions/burn.ts
+++ b/clients/js/vault_client/instructions/burn.ts
@@ -181,6 +181,7 @@ export function getBurnInstruction<
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
   TAccountBurnSigner extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: BurnInput<
     TAccountConfig,
@@ -194,9 +195,10 @@ export function getBurnInstruction<
     TAccountTokenProgram,
     TAccountSystemProgram,
     TAccountBurnSigner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): BurnInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultTokenAccount,
@@ -210,7 +212,7 @@ export function getBurnInstruction<
   TAccountBurnSigner
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -276,7 +278,7 @@ export function getBurnInstruction<
       args as BurnInstructionDataArgs
     ),
   } as BurnInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultTokenAccount,

--- a/clients/js/vault_client/instructions/burnWithdrawTicket.ts
+++ b/clients/js/vault_client/instructions/burnWithdrawTicket.ts
@@ -185,6 +185,7 @@ export function getBurnWithdrawTicketInstruction<
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
   TAccountBurnSigner extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: BurnWithdrawTicketInput<
     TAccountConfig,
@@ -199,9 +200,10 @@ export function getBurnWithdrawTicketInstruction<
     TAccountTokenProgram,
     TAccountSystemProgram,
     TAccountBurnSigner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): BurnWithdrawTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultTokenAccount,
@@ -216,7 +218,7 @@ export function getBurnWithdrawTicketInstruction<
   TAccountBurnSigner
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -287,7 +289,7 @@ export function getBurnWithdrawTicketInstruction<
       args as BurnWithdrawTicketInstructionDataArgs
     ),
   } as BurnWithdrawTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultTokenAccount,

--- a/clients/js/vault_client/instructions/changeWithdrawalTicketOwner.ts
+++ b/clients/js/vault_client/instructions/changeWithdrawalTicketOwner.ts
@@ -120,6 +120,7 @@ export function getChangeWithdrawalTicketOwnerInstruction<
   TAccountVaultStakerWithdrawalTicket extends string,
   TAccountOldOwner extends string,
   TAccountNewOwner extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: ChangeWithdrawalTicketOwnerInput<
     TAccountConfig,
@@ -127,9 +128,10 @@ export function getChangeWithdrawalTicketOwnerInstruction<
     TAccountVaultStakerWithdrawalTicket,
     TAccountOldOwner,
     TAccountNewOwner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): ChangeWithdrawalTicketOwnerInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultStakerWithdrawalTicket,
@@ -137,7 +139,7 @@ export function getChangeWithdrawalTicketOwnerInstruction<
   TAccountNewOwner
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -167,7 +169,7 @@ export function getChangeWithdrawalTicketOwnerInstruction<
     programAddress,
     data: getChangeWithdrawalTicketOwnerInstructionDataEncoder().encode({}),
   } as ChangeWithdrawalTicketOwnerInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultStakerWithdrawalTicket,

--- a/clients/js/vault_client/instructions/closeVaultUpdateStateTracker.ts
+++ b/clients/js/vault_client/instructions/closeVaultUpdateStateTracker.ts
@@ -125,22 +125,24 @@ export function getCloseVaultUpdateStateTrackerInstruction<
   TAccountVault extends string,
   TAccountVaultUpdateStateTracker extends string,
   TAccountPayer extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CloseVaultUpdateStateTrackerInput<
     TAccountConfig,
     TAccountVault,
     TAccountVaultUpdateStateTracker,
     TAccountPayer
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CloseVaultUpdateStateTrackerInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultUpdateStateTracker,
   TAccountPayer
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -173,7 +175,7 @@ export function getCloseVaultUpdateStateTrackerInstruction<
       args as CloseVaultUpdateStateTrackerInstructionDataArgs
     ),
   } as CloseVaultUpdateStateTrackerInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultUpdateStateTracker,

--- a/clients/js/vault_client/instructions/cooldownDelegation.ts
+++ b/clients/js/vault_client/instructions/cooldownDelegation.ts
@@ -127,6 +127,7 @@ export function getCooldownDelegationInstruction<
   TAccountOperator extends string,
   TAccountVaultOperatorDelegation extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CooldownDelegationInput<
     TAccountConfig,
@@ -134,9 +135,10 @@ export function getCooldownDelegationInstruction<
     TAccountOperator,
     TAccountVaultOperatorDelegation,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownDelegationInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountOperator,
@@ -144,7 +146,7 @@ export function getCooldownDelegationInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -179,7 +181,7 @@ export function getCooldownDelegationInstruction<
       args as CooldownDelegationInstructionDataArgs
     ),
   } as CooldownDelegationInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountOperator,

--- a/clients/js/vault_client/instructions/cooldownVaultNcnSlasherTicket.ts
+++ b/clients/js/vault_client/instructions/cooldownVaultNcnSlasherTicket.ts
@@ -123,6 +123,7 @@ export function getCooldownVaultNcnSlasherTicketInstruction<
   TAccountSlasher extends string,
   TAccountVaultNcnSlasherTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CooldownVaultNcnSlasherTicketInput<
     TAccountConfig,
@@ -131,9 +132,10 @@ export function getCooldownVaultNcnSlasherTicketInstruction<
     TAccountSlasher,
     TAccountVaultNcnSlasherTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownVaultNcnSlasherTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -142,7 +144,7 @@ export function getCooldownVaultNcnSlasherTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -174,7 +176,7 @@ export function getCooldownVaultNcnSlasherTicketInstruction<
     programAddress,
     data: getCooldownVaultNcnSlasherTicketInstructionDataEncoder().encode({}),
   } as CooldownVaultNcnSlasherTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/cooldownVaultNcnTicket.ts
+++ b/clients/js/vault_client/instructions/cooldownVaultNcnTicket.ts
@@ -114,6 +114,7 @@ export function getCooldownVaultNcnTicketInstruction<
   TAccountNcn extends string,
   TAccountVaultNcnTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CooldownVaultNcnTicketInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getCooldownVaultNcnTicketInstruction<
     TAccountNcn,
     TAccountVaultNcnTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CooldownVaultNcnTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -131,7 +133,7 @@ export function getCooldownVaultNcnTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +160,7 @@ export function getCooldownVaultNcnTicketInstruction<
     programAddress,
     data: getCooldownVaultNcnTicketInstructionDataEncoder().encode({}),
   } as CooldownVaultNcnTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/crankVaultUpdateStateTracker.ts
+++ b/clients/js/vault_client/instructions/crankVaultUpdateStateTracker.ts
@@ -118,6 +118,7 @@ export function getCrankVaultUpdateStateTrackerInstruction<
   TAccountOperator extends string,
   TAccountVaultOperatorDelegation extends string,
   TAccountVaultUpdateStateTracker extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CrankVaultUpdateStateTrackerInput<
     TAccountConfig,
@@ -125,9 +126,10 @@ export function getCrankVaultUpdateStateTrackerInstruction<
     TAccountOperator,
     TAccountVaultOperatorDelegation,
     TAccountVaultUpdateStateTracker
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CrankVaultUpdateStateTrackerInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountOperator,
@@ -135,7 +137,7 @@ export function getCrankVaultUpdateStateTrackerInstruction<
   TAccountVaultUpdateStateTracker
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -168,7 +170,7 @@ export function getCrankVaultUpdateStateTrackerInstruction<
     programAddress,
     data: getCrankVaultUpdateStateTrackerInstructionDataEncoder().encode({}),
   } as CrankVaultUpdateStateTrackerInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountOperator,

--- a/clients/js/vault_client/instructions/createTokenMetadata.ts
+++ b/clients/js/vault_client/instructions/createTokenMetadata.ts
@@ -164,6 +164,7 @@ export function getCreateTokenMetadataInstruction<
   TAccountMetadata extends string,
   TAccountMplTokenMetadataProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: CreateTokenMetadataInput<
     TAccountVault,
@@ -173,9 +174,10 @@ export function getCreateTokenMetadataInstruction<
     TAccountMetadata,
     TAccountMplTokenMetadataProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): CreateTokenMetadataInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountVault,
   TAccountAdmin,
   TAccountVrtMint,
@@ -185,7 +187,7 @@ export function getCreateTokenMetadataInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -234,7 +236,7 @@ export function getCreateTokenMetadataInstruction<
       args as CreateTokenMetadataInstructionDataArgs
     ),
   } as CreateTokenMetadataInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountVault,
     TAccountAdmin,
     TAccountVrtMint,

--- a/clients/js/vault_client/instructions/delegateTokenAccount.ts
+++ b/clients/js/vault_client/instructions/delegateTokenAccount.ts
@@ -132,6 +132,7 @@ export function getDelegateTokenAccountInstruction<
   TAccountTokenAccount extends string,
   TAccountDelegate extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: DelegateTokenAccountInput<
     TAccountConfig,
@@ -141,9 +142,10 @@ export function getDelegateTokenAccountInstruction<
     TAccountTokenAccount,
     TAccountDelegate,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): DelegateTokenAccountInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountDelegateAssetAdmin,
@@ -153,7 +155,7 @@ export function getDelegateTokenAccountInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -193,7 +195,7 @@ export function getDelegateTokenAccountInstruction<
     programAddress,
     data: getDelegateTokenAccountInstructionDataEncoder().encode({}),
   } as DelegateTokenAccountInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountDelegateAssetAdmin,

--- a/clients/js/vault_client/instructions/enqueueWithdrawal.ts
+++ b/clients/js/vault_client/instructions/enqueueWithdrawal.ts
@@ -171,6 +171,7 @@ export function getEnqueueWithdrawalInstruction<
   TAccountTokenProgram extends string,
   TAccountSystemProgram extends string,
   TAccountBurnSigner extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: EnqueueWithdrawalInput<
     TAccountConfig,
@@ -183,9 +184,10 @@ export function getEnqueueWithdrawalInstruction<
     TAccountTokenProgram,
     TAccountSystemProgram,
     TAccountBurnSigner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): EnqueueWithdrawalInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultStakerWithdrawalTicket,
@@ -198,7 +200,7 @@ export function getEnqueueWithdrawalInstruction<
   TAccountBurnSigner
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -259,7 +261,7 @@ export function getEnqueueWithdrawalInstruction<
       args as EnqueueWithdrawalInstructionDataArgs
     ),
   } as EnqueueWithdrawalInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultStakerWithdrawalTicket,

--- a/clients/js/vault_client/instructions/initializeConfig.ts
+++ b/clients/js/vault_client/instructions/initializeConfig.ts
@@ -108,22 +108,24 @@ export function getInitializeConfigInstruction<
   TAccountAdmin extends string,
   TAccountRestakingProgram extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeConfigInput<
     TAccountConfig,
     TAccountAdmin,
     TAccountRestakingProgram,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeConfigInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountAdmin,
   TAccountRestakingProgram,
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -157,7 +159,7 @@ export function getInitializeConfigInstruction<
     programAddress,
     data: getInitializeConfigInstructionDataEncoder().encode({}),
   } as InitializeConfigInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountAdmin,
     TAccountRestakingProgram,

--- a/clients/js/vault_client/instructions/initializeVault.ts
+++ b/clients/js/vault_client/instructions/initializeVault.ts
@@ -169,6 +169,7 @@ export function getInitializeVaultInstruction<
   TAccountBase extends string,
   TAccountSystemProgram extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultInput<
     TAccountConfig,
@@ -179,9 +180,10 @@ export function getInitializeVaultInstruction<
     TAccountBase,
     TAccountSystemProgram,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVrtMint,
@@ -192,7 +194,7 @@ export function getInitializeVaultInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -240,7 +242,7 @@ export function getInitializeVaultInstruction<
       args as InitializeVaultInstructionDataArgs
     ),
   } as InitializeVaultInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVrtMint,

--- a/clients/js/vault_client/instructions/initializeVaultNcnSlasherOperatorTicket.ts
+++ b/clients/js/vault_client/instructions/initializeVaultNcnSlasherOperatorTicket.ts
@@ -150,6 +150,7 @@ export function getInitializeVaultNcnSlasherOperatorTicketInstruction<
   TAccountVaultNcnSlasherOperatorTicket extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultNcnSlasherOperatorTicketInput<
     TAccountConfig,
@@ -161,9 +162,10 @@ export function getInitializeVaultNcnSlasherOperatorTicketInstruction<
     TAccountVaultNcnSlasherOperatorTicket,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultNcnSlasherOperatorTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -175,7 +177,7 @@ export function getInitializeVaultNcnSlasherOperatorTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -224,7 +226,7 @@ export function getInitializeVaultNcnSlasherOperatorTicketInstruction<
       {}
     ),
   } as InitializeVaultNcnSlasherOperatorTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/initializeVaultNcnSlasherTicket.ts
+++ b/clients/js/vault_client/instructions/initializeVaultNcnSlasherTicket.ts
@@ -150,6 +150,7 @@ export function getInitializeVaultNcnSlasherTicketInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultNcnSlasherTicketInput<
     TAccountConfig,
@@ -161,9 +162,10 @@ export function getInitializeVaultNcnSlasherTicketInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultNcnSlasherTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -175,7 +177,7 @@ export function getInitializeVaultNcnSlasherTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -222,7 +224,7 @@ export function getInitializeVaultNcnSlasherTicketInstruction<
     programAddress,
     data: getInitializeVaultNcnSlasherTicketInstructionDataEncoder().encode({}),
   } as InitializeVaultNcnSlasherTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/initializeVaultNcnTicket.ts
+++ b/clients/js/vault_client/instructions/initializeVaultNcnTicket.ts
@@ -139,6 +139,7 @@ export function getInitializeVaultNcnTicketInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultNcnTicketInput<
     TAccountConfig,
@@ -149,9 +150,10 @@ export function getInitializeVaultNcnTicketInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultNcnTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -162,7 +164,7 @@ export function getInitializeVaultNcnTicketInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -201,7 +203,7 @@ export function getInitializeVaultNcnTicketInstruction<
     programAddress,
     data: getInitializeVaultNcnTicketInstructionDataEncoder().encode({}),
   } as InitializeVaultNcnTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/initializeVaultOperatorDelegation.ts
+++ b/clients/js/vault_client/instructions/initializeVaultOperatorDelegation.ts
@@ -147,6 +147,7 @@ export function getInitializeVaultOperatorDelegationInstruction<
   TAccountAdmin extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultOperatorDelegationInput<
     TAccountConfig,
@@ -157,9 +158,10 @@ export function getInitializeVaultOperatorDelegationInstruction<
     TAccountAdmin,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultOperatorDelegationInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountOperator,
@@ -170,7 +172,7 @@ export function getInitializeVaultOperatorDelegationInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -217,7 +219,7 @@ export function getInitializeVaultOperatorDelegationInstruction<
       {}
     ),
   } as InitializeVaultOperatorDelegationInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountOperator,

--- a/clients/js/vault_client/instructions/initializeVaultUpdateStateTracker.ts
+++ b/clients/js/vault_client/instructions/initializeVaultUpdateStateTracker.ts
@@ -136,6 +136,7 @@ export function getInitializeVaultUpdateStateTrackerInstruction<
   TAccountVaultUpdateStateTracker extends string,
   TAccountPayer extends string,
   TAccountSystemProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: InitializeVaultUpdateStateTrackerInput<
     TAccountConfig,
@@ -143,9 +144,10 @@ export function getInitializeVaultUpdateStateTrackerInstruction<
     TAccountVaultUpdateStateTracker,
     TAccountPayer,
     TAccountSystemProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): InitializeVaultUpdateStateTrackerInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultUpdateStateTracker,
@@ -153,7 +155,7 @@ export function getInitializeVaultUpdateStateTrackerInstruction<
   TAccountSystemProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -194,7 +196,7 @@ export function getInitializeVaultUpdateStateTrackerInstruction<
       args as InitializeVaultUpdateStateTrackerInstructionDataArgs
     ),
   } as InitializeVaultUpdateStateTrackerInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultUpdateStateTracker,

--- a/clients/js/vault_client/instructions/initializeVaultWithMint.ts
+++ b/clients/js/vault_client/instructions/initializeVaultWithMint.ts
@@ -67,16 +67,19 @@ export function getInitializeVaultWithMintInstructionDataCodec(): Codec<
 
 export type InitializeVaultWithMintInput = {};
 
-export function getInitializeVaultWithMintInstruction(
-  input: InitializeVaultWithMintInput
-): InitializeVaultWithMintInstruction<typeof JITO_VAULT_PROGRAM_ADDRESS> {
+export function getInitializeVaultWithMintInstruction<
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
+>(
+  input: InitializeVaultWithMintInput,
+  config?: { programAddress?: TProgramAddress }
+): InitializeVaultWithMintInstruction<TProgramAddress> {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   const instruction = {
     programAddress,
     data: getInitializeVaultWithMintInstructionDataEncoder().encode({}),
-  } as InitializeVaultWithMintInstruction<typeof JITO_VAULT_PROGRAM_ADDRESS>;
+  } as InitializeVaultWithMintInstruction<TProgramAddress>;
 
   return instruction;
 }

--- a/clients/js/vault_client/instructions/mintTo.ts
+++ b/clients/js/vault_client/instructions/mintTo.ts
@@ -174,6 +174,7 @@ export function getMintToInstruction<
   TAccountVaultFeeTokenAccount extends string,
   TAccountTokenProgram extends string,
   TAccountMintSigner extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: MintToInput<
     TAccountConfig,
@@ -186,9 +187,10 @@ export function getMintToInstruction<
     TAccountVaultFeeTokenAccount,
     TAccountTokenProgram,
     TAccountMintSigner
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): MintToInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVrtMint,
@@ -201,7 +203,7 @@ export function getMintToInstruction<
   TAccountMintSigner
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -261,7 +263,7 @@ export function getMintToInstruction<
       args as MintToInstructionDataArgs
     ),
   } as MintToInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVrtMint,

--- a/clients/js/vault_client/instructions/setAdmin.ts
+++ b/clients/js/vault_client/instructions/setAdmin.ts
@@ -107,22 +107,24 @@ export function getSetAdminInstruction<
   TAccountVault extends string,
   TAccountOldAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: SetAdminInput<
     TAccountConfig,
     TAccountVault,
     TAccountOldAdmin,
     TAccountNewAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): SetAdminInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountOldAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -147,7 +149,7 @@ export function getSetAdminInstruction<
     programAddress,
     data: getSetAdminInstructionDataEncoder().encode({}),
   } as SetAdminInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountOldAdmin,

--- a/clients/js/vault_client/instructions/setDepositCapacity.ts
+++ b/clients/js/vault_client/instructions/setDepositCapacity.ts
@@ -111,16 +111,18 @@ export function getSetDepositCapacityInstruction<
   TAccountConfig extends string,
   TAccountVault extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
-  input: SetDepositCapacityInput<TAccountConfig, TAccountVault, TAccountAdmin>
+  input: SetDepositCapacityInput<TAccountConfig, TAccountVault, TAccountAdmin>,
+  config?: { programAddress?: TProgramAddress }
 ): SetDepositCapacityInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -148,7 +150,7 @@ export function getSetDepositCapacityInstruction<
       args as SetDepositCapacityInstructionDataArgs
     ),
   } as SetDepositCapacityInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountAdmin

--- a/clients/js/vault_client/instructions/setFees.ts
+++ b/clients/js/vault_client/instructions/setFees.ts
@@ -127,16 +127,18 @@ export function getSetFeesInstruction<
   TAccountConfig extends string,
   TAccountVault extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
-  input: SetFeesInput<TAccountConfig, TAccountVault, TAccountAdmin>
+  input: SetFeesInput<TAccountConfig, TAccountVault, TAccountAdmin>,
+  config?: { programAddress?: TProgramAddress }
 ): SetFeesInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -164,7 +166,7 @@ export function getSetFeesInstruction<
       args as SetFeesInstructionDataArgs
     ),
   } as SetFeesInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountAdmin

--- a/clients/js/vault_client/instructions/setSecondaryAdmin.ts
+++ b/clients/js/vault_client/instructions/setSecondaryAdmin.ts
@@ -124,22 +124,24 @@ export function getSetSecondaryAdminInstruction<
   TAccountVault extends string,
   TAccountAdmin extends string,
   TAccountNewAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: SetSecondaryAdminInput<
     TAccountConfig,
     TAccountVault,
     TAccountAdmin,
     TAccountNewAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): SetSecondaryAdminInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountAdmin,
   TAccountNewAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -169,7 +171,7 @@ export function getSetSecondaryAdminInstruction<
       args as SetSecondaryAdminInstructionDataArgs
     ),
   } as SetSecondaryAdminInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountAdmin,

--- a/clients/js/vault_client/instructions/slash.ts
+++ b/clients/js/vault_client/instructions/slash.ts
@@ -199,6 +199,7 @@ export function getSlashInstruction<
   TAccountVaultTokenAccount extends string,
   TAccountSlasherTokenAccount extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: SlashInput<
     TAccountConfig,
@@ -217,9 +218,10 @@ export function getSlashInstruction<
     TAccountVaultTokenAccount,
     TAccountSlasherTokenAccount,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): SlashInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -238,7 +240,7 @@ export function getSlashInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -322,7 +324,7 @@ export function getSlashInstruction<
       args as SlashInstructionDataArgs
     ),
   } as SlashInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/updateTokenMetadata.ts
+++ b/clients/js/vault_client/instructions/updateTokenMetadata.ts
@@ -146,6 +146,7 @@ export function getUpdateTokenMetadataInstruction<
   TAccountVrtMint extends string,
   TAccountMetadata extends string,
   TAccountMplTokenMetadataProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: UpdateTokenMetadataInput<
     TAccountVault,
@@ -153,9 +154,10 @@ export function getUpdateTokenMetadataInstruction<
     TAccountVrtMint,
     TAccountMetadata,
     TAccountMplTokenMetadataProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): UpdateTokenMetadataInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountVault,
   TAccountAdmin,
   TAccountVrtMint,
@@ -163,7 +165,7 @@ export function getUpdateTokenMetadataInstruction<
   TAccountMplTokenMetadataProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -204,7 +206,7 @@ export function getUpdateTokenMetadataInstruction<
       args as UpdateTokenMetadataInstructionDataArgs
     ),
   } as UpdateTokenMetadataInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountVault,
     TAccountAdmin,
     TAccountVrtMint,

--- a/clients/js/vault_client/instructions/updateVaultBalance.ts
+++ b/clients/js/vault_client/instructions/updateVaultBalance.ts
@@ -118,6 +118,7 @@ export function getUpdateVaultBalanceInstruction<
   TAccountVrtMint extends string,
   TAccountVaultFeeTokenAccount extends string,
   TAccountTokenProgram extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: UpdateVaultBalanceInput<
     TAccountConfig,
@@ -126,9 +127,10 @@ export function getUpdateVaultBalanceInstruction<
     TAccountVrtMint,
     TAccountVaultFeeTokenAccount,
     TAccountTokenProgram
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): UpdateVaultBalanceInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountVaultTokenAccount,
@@ -137,7 +139,7 @@ export function getUpdateVaultBalanceInstruction<
   TAccountTokenProgram
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -178,7 +180,7 @@ export function getUpdateVaultBalanceInstruction<
     programAddress,
     data: getUpdateVaultBalanceInstructionDataEncoder().encode({}),
   } as UpdateVaultBalanceInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountVaultTokenAccount,

--- a/clients/js/vault_client/instructions/warmupVaultNcnSlasherTicket.ts
+++ b/clients/js/vault_client/instructions/warmupVaultNcnSlasherTicket.ts
@@ -123,6 +123,7 @@ export function getWarmupVaultNcnSlasherTicketInstruction<
   TAccountSlasher extends string,
   TAccountVaultSlasherTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: WarmupVaultNcnSlasherTicketInput<
     TAccountConfig,
@@ -131,9 +132,10 @@ export function getWarmupVaultNcnSlasherTicketInstruction<
     TAccountSlasher,
     TAccountVaultSlasherTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WarmupVaultNcnSlasherTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -142,7 +144,7 @@ export function getWarmupVaultNcnSlasherTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -174,7 +176,7 @@ export function getWarmupVaultNcnSlasherTicketInstruction<
     programAddress,
     data: getWarmupVaultNcnSlasherTicketInstructionDataEncoder().encode({}),
   } as WarmupVaultNcnSlasherTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/js/vault_client/instructions/warmupVaultNcnTicket.ts
+++ b/clients/js/vault_client/instructions/warmupVaultNcnTicket.ts
@@ -114,6 +114,7 @@ export function getWarmupVaultNcnTicketInstruction<
   TAccountNcn extends string,
   TAccountVaultNcnTicket extends string,
   TAccountAdmin extends string,
+  TProgramAddress extends Address = typeof JITO_VAULT_PROGRAM_ADDRESS,
 >(
   input: WarmupVaultNcnTicketInput<
     TAccountConfig,
@@ -121,9 +122,10 @@ export function getWarmupVaultNcnTicketInstruction<
     TAccountNcn,
     TAccountVaultNcnTicket,
     TAccountAdmin
-  >
+  >,
+  config?: { programAddress?: TProgramAddress }
 ): WarmupVaultNcnTicketInstruction<
-  typeof JITO_VAULT_PROGRAM_ADDRESS,
+  TProgramAddress,
   TAccountConfig,
   TAccountVault,
   TAccountNcn,
@@ -131,7 +133,7 @@ export function getWarmupVaultNcnTicketInstruction<
   TAccountAdmin
 > {
   // Program address.
-  const programAddress = JITO_VAULT_PROGRAM_ADDRESS;
+  const programAddress = config?.programAddress ?? JITO_VAULT_PROGRAM_ADDRESS;
 
   // Original accounts.
   const originalAccounts = {
@@ -158,7 +160,7 @@ export function getWarmupVaultNcnTicketInstruction<
     programAddress,
     data: getWarmupVaultNcnTicketInstructionDataEncoder().encode({}),
   } as WarmupVaultNcnTicketInstruction<
-    typeof JITO_VAULT_PROGRAM_ADDRESS,
+    TProgramAddress,
     TAccountConfig,
     TAccountVault,
     TAccountNcn,

--- a/clients/rust/restaking_client/src/generated/instructions/cooldown_ncn_vault_slasher_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/cooldown_ncn_vault_slasher_ticket.rs
@@ -140,7 +140,7 @@ impl CooldownNcnVaultSlasherTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/cooldown_ncn_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/cooldown_ncn_vault_ticket.rs
@@ -127,7 +127,7 @@ impl CooldownNcnVaultTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/cooldown_operator_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/cooldown_operator_vault_ticket.rs
@@ -128,7 +128,7 @@ impl CooldownOperatorVaultTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_config.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_config.rs
@@ -112,7 +112,7 @@ impl InitializeConfigBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_ncn.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_ncn.rs
@@ -123,7 +123,7 @@ impl InitializeNcnBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_operator_state.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_operator_state.rs
@@ -154,7 +154,7 @@ impl InitializeNcnOperatorStateBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_vault_slasher_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_vault_slasher_ticket.rs
@@ -200,7 +200,7 @@ impl InitializeNcnVaultSlasherTicketBuilder {
         self.args = Some(args);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_ncn_vault_ticket.rs
@@ -153,7 +153,7 @@ impl InitializeNcnVaultTicketBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_operator.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_operator.rs
@@ -144,7 +144,7 @@ impl InitializeOperatorBuilder {
         self.operator_fee_bps = Some(operator_fee_bps);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/initialize_operator_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/initialize_operator_vault_ticket.rs
@@ -154,7 +154,7 @@ impl InitializeOperatorVaultTicketBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/ncn_cooldown_operator.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/ncn_cooldown_operator.rs
@@ -128,7 +128,7 @@ impl NcnCooldownOperatorBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/ncn_delegate_token_account.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/ncn_delegate_token_account.rs
@@ -140,7 +140,7 @@ impl NcnDelegateTokenAccountBuilder {
         self.token_program = Some(token_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/ncn_set_admin.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/ncn_set_admin.rs
@@ -98,7 +98,7 @@ impl NcnSetAdminBuilder {
         self.new_admin = Some(new_admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/ncn_set_secondary_admin.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/ncn_set_secondary_admin.rs
@@ -119,7 +119,7 @@ impl NcnSetSecondaryAdminBuilder {
         self.ncn_admin_role = Some(ncn_admin_role);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/ncn_warmup_operator.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/ncn_warmup_operator.rs
@@ -128,7 +128,7 @@ impl NcnWarmupOperatorBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_cooldown_ncn.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_cooldown_ncn.rs
@@ -128,7 +128,7 @@ impl OperatorCooldownNcnBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_delegate_token_account.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_delegate_token_account.rs
@@ -141,7 +141,7 @@ impl OperatorDelegateTokenAccountBuilder {
         self.token_program = Some(token_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_set_admin.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_set_admin.rs
@@ -99,7 +99,7 @@ impl OperatorSetAdminBuilder {
         self.new_admin = Some(new_admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_set_fee.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_set_fee.rs
@@ -116,7 +116,7 @@ impl OperatorSetFeeBuilder {
         self.new_fee_bps = Some(new_fee_bps);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_set_secondary_admin.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_set_secondary_admin.rs
@@ -120,7 +120,7 @@ impl OperatorSetSecondaryAdminBuilder {
         self.operator_admin_role = Some(operator_admin_role);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/operator_warmup_ncn.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/operator_warmup_ncn.rs
@@ -128,7 +128,7 @@ impl OperatorWarmupNcnBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/warmup_ncn_vault_slasher_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/warmup_ncn_vault_slasher_ticket.rs
@@ -156,7 +156,7 @@ impl WarmupNcnVaultSlasherTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/warmup_ncn_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/warmup_ncn_vault_ticket.rs
@@ -127,7 +127,7 @@ impl WarmupNcnVaultTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/restaking_client/src/generated/instructions/warmup_operator_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/generated/instructions/warmup_operator_vault_ticket.rs
@@ -128,7 +128,7 @@ impl WarmupOperatorVaultTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/add_delegation.rs
+++ b/clients/rust/vault_client/src/generated/instructions/add_delegation.rs
@@ -144,7 +144,7 @@ impl AddDelegationBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/burn.rs
+++ b/clients/rust/vault_client/src/generated/instructions/burn.rs
@@ -253,7 +253,7 @@ impl BurnBuilder {
         self.min_amount_out = Some(min_amount_out);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/burn_withdraw_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/burn_withdraw_ticket.rs
@@ -265,7 +265,7 @@ impl BurnWithdrawTicketBuilder {
         self.min_amount_out = Some(min_amount_out);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/change_withdrawal_ticket_owner.rs
+++ b/clients/rust/vault_client/src/generated/instructions/change_withdrawal_ticket_owner.rs
@@ -129,7 +129,7 @@ impl ChangeWithdrawalTicketOwnerBuilder {
         self.new_owner = Some(new_owner);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/close_vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/generated/instructions/close_vault_update_state_tracker.rs
@@ -133,7 +133,7 @@ impl CloseVaultUpdateStateTrackerBuilder {
         self.ncn_epoch = Some(ncn_epoch);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/cooldown_delegation.rs
+++ b/clients/rust/vault_client/src/generated/instructions/cooldown_delegation.rs
@@ -146,7 +146,7 @@ impl CooldownDelegationBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/cooldown_vault_ncn_slasher_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/cooldown_vault_ncn_slasher_ticket.rs
@@ -140,7 +140,7 @@ impl CooldownVaultNcnSlasherTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/cooldown_vault_ncn_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/cooldown_vault_ncn_ticket.rs
@@ -127,7 +127,7 @@ impl CooldownVaultNcnTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/crank_vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/generated/instructions/crank_vault_update_state_tracker.rs
@@ -132,7 +132,7 @@ impl CrankVaultUpdateStateTrackerBuilder {
         self.vault_update_state_tracker = Some(vault_update_state_tracker);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/create_token_metadata.rs
+++ b/clients/rust/vault_client/src/generated/instructions/create_token_metadata.rs
@@ -187,7 +187,7 @@ impl CreateTokenMetadataBuilder {
         self.uri = Some(uri);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/delegate_token_account.rs
+++ b/clients/rust/vault_client/src/generated/instructions/delegate_token_account.rs
@@ -156,7 +156,7 @@ impl DelegateTokenAccountBuilder {
         self.token_program = Some(token_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/enqueue_withdrawal.rs
+++ b/clients/rust/vault_client/src/generated/instructions/enqueue_withdrawal.rs
@@ -232,7 +232,7 @@ impl EnqueueWithdrawalBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_config.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_config.rs
@@ -115,7 +115,7 @@ impl InitializeConfigBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault.rs
@@ -202,7 +202,7 @@ impl InitializeVaultBuilder {
         self.decimals = Some(decimals);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_slasher_operator_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_slasher_operator_ticket.rs
@@ -183,7 +183,7 @@ impl InitializeVaultNcnSlasherOperatorTicketBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_slasher_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_slasher_ticket.rs
@@ -182,7 +182,7 @@ impl InitializeVaultNcnSlasherTicketBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_ncn_ticket.rs
@@ -169,7 +169,7 @@ impl InitializeVaultNcnTicketBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_operator_delegation.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_operator_delegation.rs
@@ -170,7 +170,7 @@ impl InitializeVaultOperatorDelegationBuilder {
         self.system_program = Some(system_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_update_state_tracker.rs
@@ -152,7 +152,7 @@ impl InitializeVaultUpdateStateTrackerBuilder {
         self.withdrawal_allocation_method = Some(withdrawal_allocation_method);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/initialize_vault_with_mint.rs
+++ b/clients/rust/vault_client/src/generated/instructions/initialize_vault_with_mint.rs
@@ -61,7 +61,7 @@ impl InitializeVaultWithMintBuilder {
     pub fn new() -> Self {
         Self::default()
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/mint_to.rs
+++ b/clients/rust/vault_client/src/generated/instructions/mint_to.rs
@@ -239,7 +239,7 @@ impl MintToBuilder {
         self.min_amount_out = Some(min_amount_out);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/set_admin.rs
+++ b/clients/rust/vault_client/src/generated/instructions/set_admin.rs
@@ -111,7 +111,7 @@ impl SetAdminBuilder {
         self.new_admin = Some(new_admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/set_deposit_capacity.rs
+++ b/clients/rust/vault_client/src/generated/instructions/set_deposit_capacity.rs
@@ -117,7 +117,7 @@ impl SetDepositCapacityBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/set_fees.rs
+++ b/clients/rust/vault_client/src/generated/instructions/set_fees.rs
@@ -132,7 +132,7 @@ impl SetFeesBuilder {
         self.reward_fee_bps = Some(reward_fee_bps);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/set_secondary_admin.rs
+++ b/clients/rust/vault_client/src/generated/instructions/set_secondary_admin.rs
@@ -132,7 +132,7 @@ impl SetSecondaryAdminBuilder {
         self.vault_admin_role = Some(vault_admin_role);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/slash.rs
+++ b/clients/rust/vault_client/src/generated/instructions/slash.rs
@@ -315,7 +315,7 @@ impl SlashBuilder {
         self.amount = Some(amount);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/update_token_metadata.rs
+++ b/clients/rust/vault_client/src/generated/instructions/update_token_metadata.rs
@@ -161,7 +161,7 @@ impl UpdateTokenMetadataBuilder {
         self.uri = Some(uri);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/update_vault_balance.rs
+++ b/clients/rust/vault_client/src/generated/instructions/update_vault_balance.rs
@@ -146,7 +146,7 @@ impl UpdateVaultBalanceBuilder {
         self.token_program = Some(token_program);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/warmup_vault_ncn_slasher_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/warmup_vault_ncn_slasher_ticket.rs
@@ -140,7 +140,7 @@ impl WarmupVaultNcnSlasherTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/clients/rust/vault_client/src/generated/instructions/warmup_vault_ncn_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/warmup_vault_ncn_ticket.rs
@@ -127,7 +127,7 @@ impl WarmupVaultNcnTicketBuilder {
         self.admin = Some(admin);
         self
     }
-    /// Add an aditional account to the instruction.
+    /// Add an additional account to the instruction.
     #[inline(always)]
     pub fn add_remaining_account(
         &mut self,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,21 +8,19 @@
       "name": "jito-restaking",
       "version": "0.0.2",
       "dependencies": {
-        "@kinobi-so/nodes-from-anchor": "^0.21.1",
-        "@kinobi-so/renderers": "^0.21.1",
-        "@kinobi-so/renderers-js-umi": "^0.21.1",
-        "@kinobi-so/renderers-rust": "^0.21.1",
+        "@kinobi-so/nodes-from-anchor": "^0.22.0",
+        "@kinobi-so/renderers": "^0.22.0",
         "corepack": "^0.29.3",
-        "kinobi": "^0.21.1",
+        "kinobi": "^0.22.0",
         "yarn": "2.4.3"
       }
     },
     "node_modules/@kinobi-so/errors": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/errors/-/errors-0.21.3.tgz",
-      "integrity": "sha512-vXgRsN0hfZzDBA056uKxEXEd1dxTymz1wNdkrGjwBVp2vffj3CqOUznGYYKrL5BjuptvugLqkYrBDNPXgjBEAg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/errors/-/errors-0.22.0.tgz",
+      "integrity": "sha512-E78W0dR5X0fqRcEVsYRlI/wICIIIVa3ACzZEf2KLrUgOdnQ7U2xqtfnbKGlildnejR/43RgqKw67nYy8cQwpyA==",
       "dependencies": {
-        "@kinobi-so/node-types": "0.21.3",
+        "@kinobi-so/node-types": "0.22.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
       },
@@ -31,129 +29,129 @@
       }
     },
     "node_modules/@kinobi-so/node-types": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/node-types/-/node-types-0.21.3.tgz",
-      "integrity": "sha512-3F/XKTgxPWM8sHM+8OwMV9Lgbq67Asa9yzj5yTtm0vqr7j1ROb6GMNWdTv3ZuHEdMR/csjPOGY+MONDOkA29xQ=="
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/node-types/-/node-types-0.22.0.tgz",
+      "integrity": "sha512-vC/0eBV+L+ILTQG0Kyk0QcNZR7Vl2sK+a93/bKFJyjJVQ0rDikOwcquYRFQtfovQD0zOjPJddkGPb2N03JgaNQ=="
     },
     "node_modules/@kinobi-so/nodes": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/nodes/-/nodes-0.21.3.tgz",
-      "integrity": "sha512-LzT7k4nJCzv7mfTdha1ieSGWGdopXhslgjAGZNmMnJB/byDPiLa1pjWMdJ4bGrOTl6rOff21NeAe36nuB1S9MA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/nodes/-/nodes-0.22.0.tgz",
+      "integrity": "sha512-wsLr36s0sYS8zQ9x9TOeaxhLW+T/revpbXhpZTTqb/2L+CGINtuvUgxzQWKHPzLpomRje/1yqwOYpj5QXY3CLg==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/node-types": "0.21.3"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/node-types": "0.22.0"
       }
     },
     "node_modules/@kinobi-so/nodes-from-anchor": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/nodes-from-anchor/-/nodes-from-anchor-0.21.1.tgz",
-      "integrity": "sha512-yJimfb593+qSKAYr6KbmiWRU/hTT49PfBRw1DENW48DgAwCjOS+1nlQjmXV/dglGF7JmYBo3ZcEtu5nYUwr/Eg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/nodes-from-anchor/-/nodes-from-anchor-0.22.0.tgz",
+      "integrity": "sha512-QNBZ5bxWl24jJQ+DwcAuMulawxW0B0Q2eEMrauFgXIa5ztXw4txIVydkwSaOdTivE2yhQXR06pg5jLIF/zJ3Rw==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/visitors": "0.21.3",
-        "@noble/hashes": "^1.4.0"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/visitors": "0.22.0",
+        "@noble/hashes": "^1.5.0"
       }
     },
     "node_modules/@kinobi-so/renderers": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers/-/renderers-0.21.1.tgz",
-      "integrity": "sha512-x07ECGGf1hCXbvFa/cHfMrHgavhfsgcPypuxhgGzDirgjsn9CwxNA22cNK7QPz9gDKIyYVoxc09we7KWkTldcg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers/-/renderers-0.22.0.tgz",
+      "integrity": "sha512-lWjToFigc7eOFKezQUXuSlk04K8WRzizOlSk+Pf24tAdywT/0fcaKYLHvriivv8n4AJ2UIKuyBJkvFWZBmfRpg==",
       "dependencies": {
-        "@kinobi-so/renderers-js": "0.21.6",
-        "@kinobi-so/renderers-js-umi": "0.21.5",
-        "@kinobi-so/renderers-rust": "0.21.5"
+        "@kinobi-so/renderers-js": "0.22.0",
+        "@kinobi-so/renderers-js-umi": "0.22.0",
+        "@kinobi-so/renderers-rust": "0.22.0"
       }
     },
     "node_modules/@kinobi-so/renderers-core": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-core/-/renderers-core-0.21.1.tgz",
-      "integrity": "sha512-dqSPwuAhrrhu4ECJNIJymHkKAfbU/c2HnLT0U/2V1+PwimQZgjW0nNSQTbbACw1NcvVZM/XFd459Z3e8axRJsQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-core/-/renderers-core-0.22.0.tgz",
+      "integrity": "sha512-m151uCRuCsgzA7mdT+3GYVzpct4h7dEGydda+h6UDbsuk7dcA6aVx4OVXYhF0TY/xKhw4MTBzluvwrcAZzFzMA==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/visitors-core": "0.21.3"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0"
       }
     },
     "node_modules/@kinobi-so/renderers-js": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-js/-/renderers-js-0.21.6.tgz",
-      "integrity": "sha512-B/Z7QE3bAxFdeO4JY/dD6wQmmkv7FZa8tn75CmNwc1B9/An+Z/AGqnqubf3op+SmpfKcCWJmToI0bXWAV4p9aA==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-js/-/renderers-js-0.22.0.tgz",
+      "integrity": "sha512-ASgjgXbTmKLf8SWQlTJe5RKqpe/t0Jk0AQ2pN1yWfF1AiT8ogMjHnkV1yYDJ5oqCNiAnwO4R6TS8bzE77AEFjw==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/nodes-from-anchor": "0.21.1",
-        "@kinobi-so/renderers-core": "0.21.1",
-        "@kinobi-so/visitors-core": "0.21.3",
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/nodes-from-anchor": "0.22.0",
+        "@kinobi-so/renderers-core": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0",
         "@solana/codecs-strings": "rc",
         "nunjucks": "^3.2.4",
         "prettier": "^3.3.3"
       }
     },
     "node_modules/@kinobi-so/renderers-js-umi": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-js-umi/-/renderers-js-umi-0.21.5.tgz",
-      "integrity": "sha512-kN4jIm86j6Umf/ephiX9SZDV4zUCVKr0hiUrSejnNvVTosOfm3s9nQq/GzCxSVNMRhkEehy6jahlJ3O2si6jJQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-js-umi/-/renderers-js-umi-0.22.0.tgz",
+      "integrity": "sha512-n0Yz2xyulgtkICAzFHCdCFRl6Axs556co3aAkM8ggMGQrDBMaz3y7MHNof/95yGEqhUBPlLKsix2NqiOq3/Avg==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/renderers-core": "0.21.1",
-        "@kinobi-so/validators": "0.21.3",
-        "@kinobi-so/visitors-core": "0.21.3",
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/renderers-core": "0.22.0",
+        "@kinobi-so/validators": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0",
         "@solana/codecs-strings": "rc",
         "nunjucks": "^3.2.4",
         "prettier": "^3.3.3"
       }
     },
     "node_modules/@kinobi-so/renderers-rust": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-rust/-/renderers-rust-0.21.5.tgz",
-      "integrity": "sha512-dLrfp1rMlVvS4ubrcbXgPbJ8P6kMU0AcokbZQxDSDCv/TKCTG+SaS0IROKmd5z+3cxgMdBUY74GETbPlaiwGFw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/renderers-rust/-/renderers-rust-0.22.0.tgz",
+      "integrity": "sha512-1tgbWWivfXepZefwVTwvYfzlebUILmDGRMI/9t6bYNPDh1G0UqH0aHig2qm8bKUIMBiU0wmnFLOAkCCcmld3Cw==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/renderers-core": "0.21.1",
-        "@kinobi-so/visitors-core": "0.21.3",
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/renderers-core": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0",
         "@solana/codecs-strings": "rc",
         "nunjucks": "^3.2.4"
       }
     },
     "node_modules/@kinobi-so/validators": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/validators/-/validators-0.21.3.tgz",
-      "integrity": "sha512-4d/6zWxNH6j6DMM3V7Ry8ZnVMS93vRrSiD3ZTEZ+IQuQSMJUg7imeOK2tyq4eADbX2du16hYgVH1zj+eEqOdKw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/validators/-/validators-0.22.0.tgz",
+      "integrity": "sha512-sx03aFRyvOxfx6pCjPF/W7hpzU4buylkhZXd1/HqRIHJz17DMvWDV4y6uczb3mDroVj4J2Wq+2XWlwGU9H3FBg==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/visitors-core": "0.21.3"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0"
       }
     },
     "node_modules/@kinobi-so/visitors": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/visitors/-/visitors-0.21.3.tgz",
-      "integrity": "sha512-1KTFMLMMBkzIYhCDdFknc1LEMITbkMt0z4JIx62s+7jI/HBHr5cRP54+D0gvp04lq0x/JgKYdhGZnr0WiZ1tTg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/visitors/-/visitors-0.22.0.tgz",
+      "integrity": "sha512-BN1CKgSmZ+pLKAao2YDfo2cqS6TLxGaxgqAL7oeItlKSZdOAoJMmieER7EE7pqQODRzLmnLKLeHmnYSc4kg/Fw==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/visitors-core": "0.21.3"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/visitors-core": "0.22.0"
       }
     },
     "node_modules/@kinobi-so/visitors-core": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@kinobi-so/visitors-core/-/visitors-core-0.21.3.tgz",
-      "integrity": "sha512-QvF7RzC9V+vIv8TE6DrQenf65swS/R+WmOeKDTsoZkY0fTfOt8qDCbv2tAM4q8EpvZHhx/4mDIKjWRPr+FRlAQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@kinobi-so/visitors-core/-/visitors-core-0.22.0.tgz",
+      "integrity": "sha512-PM9UNzWEAHjctgtR7qZFeGAqQWxVqfidVbYMFcRxUvd411+Yj+i0ByrHBe8J2N7mwlwiqYwcDBJDLE2Yr2ljuw==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
         "json-stable-stringify": "^1.1.1"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -426,14 +424,14 @@
       }
     },
     "node_modules/kinobi": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/kinobi/-/kinobi-0.21.3.tgz",
-      "integrity": "sha512-1/Cd8GZ50S2/s8DdiDuow/gBLcpnWJF7jpwNrCcofnpwqDl6d+CbJgSwzdnkhJthGxkCXGpqvoSKud0QedCKfg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/kinobi/-/kinobi-0.22.0.tgz",
+      "integrity": "sha512-qhYuzfWXC7KgORs/jvY9vJE+jmD6xhI5QUiXTnQk8D+VyBt0Geuc1ZbZ1PRI69SOO7CAX9Bc0i0tTrtb09Z/Kg==",
       "dependencies": {
-        "@kinobi-so/errors": "0.21.3",
-        "@kinobi-so/nodes": "0.21.3",
-        "@kinobi-so/validators": "0.21.3",
-        "@kinobi-so/visitors": "0.21.3"
+        "@kinobi-so/errors": "0.22.0",
+        "@kinobi-so/nodes": "0.22.0",
+        "@kinobi-so/validators": "0.22.0",
+        "@kinobi-so/visitors": "0.22.0"
       }
     },
     "node_modules/nunjucks": {
@@ -507,9 +505,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,10 @@
   "version": "0.0.2",
   "description": "Jito Restaking",
   "dependencies": {
-    "@kinobi-so/nodes-from-anchor": "^0.21.1",
-    "@kinobi-so/renderers": "^0.21.1",
-    "@kinobi-so/renderers-js-umi": "^0.21.1",
-    "@kinobi-so/renderers-rust": "^0.21.1",
+    "@kinobi-so/nodes-from-anchor": "^0.22.0",
+    "@kinobi-so/renderers": "^0.22.0",
     "corepack": "^0.29.3",
-    "kinobi": "^0.21.1",
+    "kinobi": "^0.22.0",
     "yarn": "2.4.3"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,127 +2,127 @@
 # yarn lockfile v1
 
 
-"@kinobi-so/errors@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/errors/-/errors-0.21.3.tgz"
-  integrity sha512-vXgRsN0hfZzDBA056uKxEXEd1dxTymz1wNdkrGjwBVp2vffj3CqOUznGYYKrL5BjuptvugLqkYrBDNPXgjBEAg==
+"@kinobi-so/errors@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/errors/-/errors-0.22.0.tgz"
+  integrity sha512-E78W0dR5X0fqRcEVsYRlI/wICIIIVa3ACzZEf2KLrUgOdnQ7U2xqtfnbKGlildnejR/43RgqKw67nYy8cQwpyA==
   dependencies:
-    "@kinobi-so/node-types" "0.21.3"
+    "@kinobi-so/node-types" "0.22.0"
     chalk "^5.3.0"
     commander "^12.1.0"
 
-"@kinobi-so/node-types@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/node-types/-/node-types-0.21.3.tgz"
-  integrity sha512-3F/XKTgxPWM8sHM+8OwMV9Lgbq67Asa9yzj5yTtm0vqr7j1ROb6GMNWdTv3ZuHEdMR/csjPOGY+MONDOkA29xQ==
+"@kinobi-so/node-types@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/node-types/-/node-types-0.22.0.tgz"
+  integrity sha512-vC/0eBV+L+ILTQG0Kyk0QcNZR7Vl2sK+a93/bKFJyjJVQ0rDikOwcquYRFQtfovQD0zOjPJddkGPb2N03JgaNQ==
 
-"@kinobi-so/nodes-from-anchor@0.21.1", "@kinobi-so/nodes-from-anchor@^0.21.1":
-  version "0.21.1"
-  resolved "https://registry.npmjs.org/@kinobi-so/nodes-from-anchor/-/nodes-from-anchor-0.21.1.tgz"
-  integrity sha512-yJimfb593+qSKAYr6KbmiWRU/hTT49PfBRw1DENW48DgAwCjOS+1nlQjmXV/dglGF7JmYBo3ZcEtu5nYUwr/Eg==
+"@kinobi-so/nodes-from-anchor@^0.22.0", "@kinobi-so/nodes-from-anchor@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/nodes-from-anchor/-/nodes-from-anchor-0.22.0.tgz"
+  integrity sha512-QNBZ5bxWl24jJQ+DwcAuMulawxW0B0Q2eEMrauFgXIa5ztXw4txIVydkwSaOdTivE2yhQXR06pg5jLIF/zJ3Rw==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/visitors" "0.21.3"
-    "@noble/hashes" "^1.4.0"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/visitors" "0.22.0"
+    "@noble/hashes" "^1.5.0"
 
-"@kinobi-so/nodes@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/nodes/-/nodes-0.21.3.tgz"
-  integrity sha512-LzT7k4nJCzv7mfTdha1ieSGWGdopXhslgjAGZNmMnJB/byDPiLa1pjWMdJ4bGrOTl6rOff21NeAe36nuB1S9MA==
+"@kinobi-so/nodes@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/nodes/-/nodes-0.22.0.tgz"
+  integrity sha512-wsLr36s0sYS8zQ9x9TOeaxhLW+T/revpbXhpZTTqb/2L+CGINtuvUgxzQWKHPzLpomRje/1yqwOYpj5QXY3CLg==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/node-types" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/node-types" "0.22.0"
 
-"@kinobi-so/renderers-core@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.npmjs.org/@kinobi-so/renderers-core/-/renderers-core-0.21.1.tgz"
-  integrity sha512-dqSPwuAhrrhu4ECJNIJymHkKAfbU/c2HnLT0U/2V1+PwimQZgjW0nNSQTbbACw1NcvVZM/XFd459Z3e8axRJsQ==
+"@kinobi-so/renderers-core@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/renderers-core/-/renderers-core-0.22.0.tgz"
+  integrity sha512-m151uCRuCsgzA7mdT+3GYVzpct4h7dEGydda+h6UDbsuk7dcA6aVx4OVXYhF0TY/xKhw4MTBzluvwrcAZzFzMA==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
 
-"@kinobi-so/renderers-js-umi@0.21.5", "@kinobi-so/renderers-js-umi@^0.21.1":
-  version "0.21.5"
-  resolved "https://registry.npmjs.org/@kinobi-so/renderers-js-umi/-/renderers-js-umi-0.21.5.tgz"
-  integrity sha512-kN4jIm86j6Umf/ephiX9SZDV4zUCVKr0hiUrSejnNvVTosOfm3s9nQq/GzCxSVNMRhkEehy6jahlJ3O2si6jJQ==
+"@kinobi-so/renderers-js-umi@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/renderers-js-umi/-/renderers-js-umi-0.22.0.tgz"
+  integrity sha512-n0Yz2xyulgtkICAzFHCdCFRl6Axs556co3aAkM8ggMGQrDBMaz3y7MHNof/95yGEqhUBPlLKsix2NqiOq3/Avg==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/renderers-core" "0.21.1"
-    "@kinobi-so/validators" "0.21.3"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/renderers-core" "0.22.0"
+    "@kinobi-so/validators" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
     "@solana/codecs-strings" rc
     nunjucks "^3.2.4"
     prettier "^3.3.3"
 
-"@kinobi-so/renderers-js@0.21.6":
-  version "0.21.6"
-  resolved "https://registry.npmjs.org/@kinobi-so/renderers-js/-/renderers-js-0.21.6.tgz"
-  integrity sha512-B/Z7QE3bAxFdeO4JY/dD6wQmmkv7FZa8tn75CmNwc1B9/An+Z/AGqnqubf3op+SmpfKcCWJmToI0bXWAV4p9aA==
+"@kinobi-so/renderers-js@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/renderers-js/-/renderers-js-0.22.0.tgz"
+  integrity sha512-ASgjgXbTmKLf8SWQlTJe5RKqpe/t0Jk0AQ2pN1yWfF1AiT8ogMjHnkV1yYDJ5oqCNiAnwO4R6TS8bzE77AEFjw==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/nodes-from-anchor" "0.21.1"
-    "@kinobi-so/renderers-core" "0.21.1"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/nodes-from-anchor" "0.22.0"
+    "@kinobi-so/renderers-core" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
     "@solana/codecs-strings" rc
     nunjucks "^3.2.4"
     prettier "^3.3.3"
 
-"@kinobi-so/renderers-rust@0.21.5", "@kinobi-so/renderers-rust@^0.21.1":
-  version "0.21.5"
-  resolved "https://registry.npmjs.org/@kinobi-so/renderers-rust/-/renderers-rust-0.21.5.tgz"
-  integrity sha512-dLrfp1rMlVvS4ubrcbXgPbJ8P6kMU0AcokbZQxDSDCv/TKCTG+SaS0IROKmd5z+3cxgMdBUY74GETbPlaiwGFw==
+"@kinobi-so/renderers-rust@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/renderers-rust/-/renderers-rust-0.22.0.tgz"
+  integrity sha512-1tgbWWivfXepZefwVTwvYfzlebUILmDGRMI/9t6bYNPDh1G0UqH0aHig2qm8bKUIMBiU0wmnFLOAkCCcmld3Cw==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/renderers-core" "0.21.1"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/renderers-core" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
     "@solana/codecs-strings" rc
     nunjucks "^3.2.4"
 
-"@kinobi-so/renderers@^0.21.1":
-  version "0.21.1"
-  resolved "https://registry.npmjs.org/@kinobi-so/renderers/-/renderers-0.21.1.tgz"
-  integrity sha512-x07ECGGf1hCXbvFa/cHfMrHgavhfsgcPypuxhgGzDirgjsn9CwxNA22cNK7QPz9gDKIyYVoxc09we7KWkTldcg==
+"@kinobi-so/renderers@^0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/renderers/-/renderers-0.22.0.tgz"
+  integrity sha512-lWjToFigc7eOFKezQUXuSlk04K8WRzizOlSk+Pf24tAdywT/0fcaKYLHvriivv8n4AJ2UIKuyBJkvFWZBmfRpg==
   dependencies:
-    "@kinobi-so/renderers-js" "0.21.6"
-    "@kinobi-so/renderers-js-umi" "0.21.5"
-    "@kinobi-so/renderers-rust" "0.21.5"
+    "@kinobi-so/renderers-js" "0.22.0"
+    "@kinobi-so/renderers-js-umi" "0.22.0"
+    "@kinobi-so/renderers-rust" "0.22.0"
 
-"@kinobi-so/validators@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/validators/-/validators-0.21.3.tgz"
-  integrity sha512-4d/6zWxNH6j6DMM3V7Ry8ZnVMS93vRrSiD3ZTEZ+IQuQSMJUg7imeOK2tyq4eADbX2du16hYgVH1zj+eEqOdKw==
+"@kinobi-so/validators@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/validators/-/validators-0.22.0.tgz"
+  integrity sha512-sx03aFRyvOxfx6pCjPF/W7hpzU4buylkhZXd1/HqRIHJz17DMvWDV4y6uczb3mDroVj4J2Wq+2XWlwGU9H3FBg==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
 
-"@kinobi-so/visitors-core@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/visitors-core/-/visitors-core-0.21.3.tgz"
-  integrity sha512-QvF7RzC9V+vIv8TE6DrQenf65swS/R+WmOeKDTsoZkY0fTfOt8qDCbv2tAM4q8EpvZHhx/4mDIKjWRPr+FRlAQ==
+"@kinobi-so/visitors-core@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/visitors-core/-/visitors-core-0.22.0.tgz"
+  integrity sha512-PM9UNzWEAHjctgtR7qZFeGAqQWxVqfidVbYMFcRxUvd411+Yj+i0ByrHBe8J2N7mwlwiqYwcDBJDLE2Yr2ljuw==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
     json-stable-stringify "^1.1.1"
 
-"@kinobi-so/visitors@0.21.3":
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/@kinobi-so/visitors/-/visitors-0.21.3.tgz"
-  integrity sha512-1KTFMLMMBkzIYhCDdFknc1LEMITbkMt0z4JIx62s+7jI/HBHr5cRP54+D0gvp04lq0x/JgKYdhGZnr0WiZ1tTg==
+"@kinobi-so/visitors@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/@kinobi-so/visitors/-/visitors-0.22.0.tgz"
+  integrity sha512-BN1CKgSmZ+pLKAao2YDfo2cqS6TLxGaxgqAL7oeItlKSZdOAoJMmieER7EE7pqQODRzLmnLKLeHmnYSc4kg/Fw==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/visitors-core" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/visitors-core" "0.22.0"
 
-"@noble/hashes@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz"
-  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+"@noble/hashes@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
+  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
 
 "@solana/codecs-core@2.0.0-rc.1":
   version "2.0.0-rc.1"
@@ -218,6 +218,11 @@ es-errors@^1.3.0:
   resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -285,15 +290,15 @@ jsonify@^0.0.1:
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz"
   integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
-kinobi@^0.21.1:
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/kinobi/-/kinobi-0.21.3.tgz"
-  integrity sha512-1/Cd8GZ50S2/s8DdiDuow/gBLcpnWJF7jpwNrCcofnpwqDl6d+CbJgSwzdnkhJthGxkCXGpqvoSKud0QedCKfg==
+kinobi@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.npmjs.org/kinobi/-/kinobi-0.22.0.tgz"
+  integrity sha512-qhYuzfWXC7KgORs/jvY9vJE+jmD6xhI5QUiXTnQk8D+VyBt0Geuc1ZbZ1PRI69SOO7CAX9Bc0i0tTrtb09Z/Kg==
   dependencies:
-    "@kinobi-so/errors" "0.21.3"
-    "@kinobi-so/nodes" "0.21.3"
-    "@kinobi-so/validators" "0.21.3"
-    "@kinobi-so/visitors" "0.21.3"
+    "@kinobi-so/errors" "0.22.0"
+    "@kinobi-so/nodes" "0.22.0"
+    "@kinobi-so/validators" "0.22.0"
+    "@kinobi-so/visitors" "0.22.0"
 
 nunjucks@^3.2.4:
   version "3.2.4"
@@ -325,6 +330,11 @@ set-function-length@^1.2.1:
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
+
+typescript@>=5:
+  version "5.6.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz"
+  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 yarn@2.4.3:
   version "2.4.3"


### PR DESCRIPTION
#### Motivation
- There are some typo in the code that generated from kinobi

```txt
error: `aditional` should be `additional`
  --> ./clients/rust/vault_client/src/generated/instructions/initialize_config.rs:118:16
    |
118 |     /// Add an aditional account to the instruction.
    |                ^^^^^^^^^
    |
error: `aditional` should be `additional`
  --> ./clients/rust/vault_client/src/generated/instructions/warmup_vault_ncn_slasher_ticket.rs:143:16
    |
143 |     /// Add an aditional account to the instruction.
    |                ^^^^^^^^^
    |
error: `aditional` should be `additional`
  --> ./clients/rust/vault_client/src/generated/instructions/initialize_vault_update_state_tracker.rs:155:16
    |
155 |     /// Add an aditional account to the instruction.
    |                ^^^^^^^^^
    |
```

#### Solution
- Upgrade kinobi from `0.21.1` to `0.22.0`