### PR TITLE
Standardize on Withdrawal everywhere

### DIFF
--- a/clients/js/vault_client/instructions/burnWithdrawalTicket.ts
+++ b/clients/js/vault_client/instructions/burnWithdrawalTicket.ts
@@ -32,13 +32,13 @@ import {
 import { JITO_VAULT_PROGRAM_ADDRESS } from '../programs';
 import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 
-export const BURN_WITHDRAW_TICKET_DISCRIMINATOR = 15;
+export const BURN_WITHDRAWAL_TICKET_DISCRIMINATOR = 15;
 
-export function getBurnWithdrawTicketDiscriminatorBytes() {
-  return getU8Encoder().encode(BURN_WITHDRAW_TICKET_DISCRIMINATOR);
+export function getBurnWithdrawalTicketDiscriminatorBytes() {
+  return getU8Encoder().encode(BURN_WITHDRAWAL_TICKET_DISCRIMINATOR);
 }
 
-export type BurnWithdrawTicketInstruction<
+export type BurnWithdrawalTicketInstruction<
   TProgram extends string = typeof JITO_VAULT_PROGRAM_ADDRESS,
   TAccountConfig extends string | IAccountMeta<string> = string,
   TAccountVault extends string | IAccountMeta<string> = string,
@@ -106,43 +106,46 @@ export type BurnWithdrawTicketInstruction<
     ]
   >;
 
-export type BurnWithdrawTicketInstructionData = {
+export type BurnWithdrawalTicketInstructionData = {
   discriminator: number;
   minAmountOut: bigint;
 };
 
-export type BurnWithdrawTicketInstructionDataArgs = {
+export type BurnWithdrawalTicketInstructionDataArgs = {
   minAmountOut: number | bigint;
 };
 
-export function getBurnWithdrawTicketInstructionDataEncoder(): Encoder<BurnWithdrawTicketInstructionDataArgs> {
+export function getBurnWithdrawalTicketInstructionDataEncoder(): Encoder<BurnWithdrawalTicketInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
       ['discriminator', getU8Encoder()],
       ['minAmountOut', getU64Encoder()],
     ]),
-    (value) => ({ ...value, discriminator: BURN_WITHDRAW_TICKET_DISCRIMINATOR })
+    (value) => ({
+      ...value,
+      discriminator: BURN_WITHDRAWAL_TICKET_DISCRIMINATOR,
+    })
   );
 }
 
-export function getBurnWithdrawTicketInstructionDataDecoder(): Decoder<BurnWithdrawTicketInstructionData> {
+export function getBurnWithdrawalTicketInstructionDataDecoder(): Decoder<BurnWithdrawalTicketInstructionData> {
   return getStructDecoder([
     ['discriminator', getU8Decoder()],
     ['minAmountOut', getU64Decoder()],
   ]);
 }
 
-export function getBurnWithdrawTicketInstructionDataCodec(): Codec<
-  BurnWithdrawTicketInstructionDataArgs,
-  BurnWithdrawTicketInstructionData
+export function getBurnWithdrawalTicketInstructionDataCodec(): Codec<
+  BurnWithdrawalTicketInstructionDataArgs,
+  BurnWithdrawalTicketInstructionData
 > {
   return combineCodec(
-    getBurnWithdrawTicketInstructionDataEncoder(),
-    getBurnWithdrawTicketInstructionDataDecoder()
+    getBurnWithdrawalTicketInstructionDataEncoder(),
+    getBurnWithdrawalTicketInstructionDataDecoder()
   );
 }
 
-export type BurnWithdrawTicketInput<
+export type BurnWithdrawalTicketInput<
   TAccountConfig extends string = string,
   TAccountVault extends string = string,
   TAccountVaultTokenAccount extends string = string,
@@ -169,10 +172,10 @@ export type BurnWithdrawTicketInput<
   systemProgram?: Address<TAccountSystemProgram>;
   /** Signer for burning */
   burnSigner?: TransactionSigner<TAccountBurnSigner>;
-  minAmountOut: BurnWithdrawTicketInstructionDataArgs['minAmountOut'];
+  minAmountOut: BurnWithdrawalTicketInstructionDataArgs['minAmountOut'];
 };
 
-export function getBurnWithdrawTicketInstruction<
+export function getBurnWithdrawalTicketInstruction<
   TAccountConfig extends string,
   TAccountVault extends string,
   TAccountVaultTokenAccount extends string,
@@ -186,7 +189,7 @@ export function getBurnWithdrawTicketInstruction<
   TAccountSystemProgram extends string,
   TAccountBurnSigner extends string,
 >(
-  input: BurnWithdrawTicketInput<
+  input: BurnWithdrawalTicketInput<
     TAccountConfig,
     TAccountVault,
     TAccountVaultTokenAccount,
@@ -200,7 +203,7 @@ export function getBurnWithdrawTicketInstruction<
     TAccountSystemProgram,
     TAccountBurnSigner
   >
-): BurnWithdrawTicketInstruction<
+): BurnWithdrawalTicketInstruction<
   typeof JITO_VAULT_PROGRAM_ADDRESS,
   TAccountConfig,
   TAccountVault,
@@ -283,10 +286,10 @@ export function getBurnWithdrawTicketInstruction<
       getAccountMeta(accounts.burnSigner),
     ],
     programAddress,
-    data: getBurnWithdrawTicketInstructionDataEncoder().encode(
-      args as BurnWithdrawTicketInstructionDataArgs
+    data: getBurnWithdrawalTicketInstructionDataEncoder().encode(
+      args as BurnWithdrawalTicketInstructionDataArgs
     ),
-  } as BurnWithdrawTicketInstruction<
+  } as BurnWithdrawalTicketInstruction<
     typeof JITO_VAULT_PROGRAM_ADDRESS,
     TAccountConfig,
     TAccountVault,
@@ -305,7 +308,7 @@ export function getBurnWithdrawTicketInstruction<
   return instruction;
 }
 
-export type ParsedBurnWithdrawTicketInstruction<
+export type ParsedBurnWithdrawalTicketInstruction<
   TProgram extends string = typeof JITO_VAULT_PROGRAM_ADDRESS,
   TAccountMetas extends readonly IAccountMeta[] = readonly IAccountMeta[],
 > = {
@@ -325,17 +328,17 @@ export type ParsedBurnWithdrawTicketInstruction<
     /** Signer for burning */
     burnSigner?: TAccountMetas[11] | undefined;
   };
-  data: BurnWithdrawTicketInstructionData;
+  data: BurnWithdrawalTicketInstructionData;
 };
 
-export function parseBurnWithdrawTicketInstruction<
+export function parseBurnWithdrawalTicketInstruction<
   TProgram extends string,
   TAccountMetas extends readonly IAccountMeta[],
 >(
   instruction: IInstruction<TProgram> &
     IInstructionWithAccounts<TAccountMetas> &
     IInstructionWithData<Uint8Array>
-): ParsedBurnWithdrawTicketInstruction<TProgram, TAccountMetas> {
+): ParsedBurnWithdrawalTicketInstruction<TProgram, TAccountMetas> {
   if (instruction.accounts.length < 12) {
     // TODO: Coded error.
     throw new Error('Not enough accounts');
@@ -368,7 +371,7 @@ export function parseBurnWithdrawTicketInstruction<
       systemProgram: getNextAccount(),
       burnSigner: getNextOptionalAccount(),
     },
-    data: getBurnWithdrawTicketInstructionDataDecoder().decode(
+    data: getBurnWithdrawalTicketInstructionDataDecoder().decode(
       instruction.data
     ),
   };

--- a/clients/js/vault_client/instructions/index.ts
+++ b/clients/js/vault_client/instructions/index.ts
@@ -8,7 +8,7 @@
 
 export * from './addDelegation';
 export * from './burn';
-export * from './burnWithdrawTicket';
+export * from './burnWithdrawalTicket';
 export * from './changeWithdrawalTicketOwner';
 export * from './closeVaultUpdateStateTracker';
 export * from './cooldownDelegation';

--- a/clients/js/vault_client/programs/jitoVault.ts
+++ b/clients/js/vault_client/programs/jitoVault.ts
@@ -15,7 +15,7 @@ import {
 import {
   type ParsedAddDelegationInstruction,
   type ParsedBurnInstruction,
-  type ParsedBurnWithdrawTicketInstruction,
+  type ParsedBurnWithdrawalTicketInstruction,
   type ParsedChangeWithdrawalTicketOwnerInstruction,
   type ParsedCloseVaultUpdateStateTrackerInstruction,
   type ParsedCooldownDelegationInstruction,
@@ -75,7 +75,7 @@ export enum JitoVaultInstruction {
   Burn,
   EnqueueWithdrawal,
   ChangeWithdrawalTicketOwner,
-  BurnWithdrawTicket,
+  BurnWithdrawalTicket,
   SetDepositCapacity,
   SetFees,
   DelegateTokenAccount,
@@ -142,7 +142,7 @@ export function identifyJitoVaultInstruction(
     return JitoVaultInstruction.ChangeWithdrawalTicketOwner;
   }
   if (containsBytes(data, getU8Encoder().encode(15), 0)) {
-    return JitoVaultInstruction.BurnWithdrawTicket;
+    return JitoVaultInstruction.BurnWithdrawalTicket;
   }
   if (containsBytes(data, getU8Encoder().encode(16), 0)) {
     return JitoVaultInstruction.SetDepositCapacity;
@@ -240,8 +240,8 @@ export type ParsedJitoVaultInstruction<
       instructionType: JitoVaultInstruction.ChangeWithdrawalTicketOwner;
     } & ParsedChangeWithdrawalTicketOwnerInstruction<TProgram>)
   | ({
-      instructionType: JitoVaultInstruction.BurnWithdrawTicket;
-    } & ParsedBurnWithdrawTicketInstruction<TProgram>)
+      instructionType: JitoVaultInstruction.BurnWithdrawalTicket;
+    } & ParsedBurnWithdrawalTicketInstruction<TProgram>)
   | ({
       instructionType: JitoVaultInstruction.SetDepositCapacity;
     } & ParsedSetDepositCapacityInstruction<TProgram>)

--- a/clients/rust/vault_client/src/generated/instructions/burn_withdrawal_ticket.rs
+++ b/clients/rust/vault_client/src/generated/instructions/burn_withdrawal_ticket.rs
@@ -7,7 +7,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 
 /// Accounts.
-pub struct BurnWithdrawTicket {
+pub struct BurnWithdrawalTicket {
     pub config: solana_program::pubkey::Pubkey,
 
     pub vault: solana_program::pubkey::Pubkey,
@@ -33,17 +33,17 @@ pub struct BurnWithdrawTicket {
     pub burn_signer: Option<solana_program::pubkey::Pubkey>,
 }
 
-impl BurnWithdrawTicket {
+impl BurnWithdrawalTicket {
     pub fn instruction(
         &self,
-        args: BurnWithdrawTicketInstructionArgs,
+        args: BurnWithdrawalTicketInstructionArgs,
     ) -> solana_program::instruction::Instruction {
         self.instruction_with_remaining_accounts(args, &[])
     }
     #[allow(clippy::vec_init_then_push)]
     pub fn instruction_with_remaining_accounts(
         &self,
-        args: BurnWithdrawTicketInstructionArgs,
+        args: BurnWithdrawalTicketInstructionArgs,
         remaining_accounts: &[solana_program::instruction::AccountMeta],
     ) -> solana_program::instruction::Instruction {
         let mut accounts = Vec::with_capacity(12 + remaining_accounts.len());
@@ -102,7 +102,7 @@ impl BurnWithdrawTicket {
             ));
         }
         accounts.extend_from_slice(remaining_accounts);
-        let mut data = BurnWithdrawTicketInstructionData::new()
+        let mut data = BurnWithdrawalTicketInstructionData::new()
             .try_to_vec()
             .unwrap();
         let mut args = args.try_to_vec().unwrap();
@@ -117,17 +117,17 @@ impl BurnWithdrawTicket {
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
-pub struct BurnWithdrawTicketInstructionData {
+pub struct BurnWithdrawalTicketInstructionData {
     discriminator: u8,
 }
 
-impl BurnWithdrawTicketInstructionData {
+impl BurnWithdrawalTicketInstructionData {
     pub fn new() -> Self {
         Self { discriminator: 15 }
     }
 }
 
-impl Default for BurnWithdrawTicketInstructionData {
+impl Default for BurnWithdrawalTicketInstructionData {
     fn default() -> Self {
         Self::new()
     }
@@ -135,11 +135,11 @@ impl Default for BurnWithdrawTicketInstructionData {
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BurnWithdrawTicketInstructionArgs {
+pub struct BurnWithdrawalTicketInstructionArgs {
     pub min_amount_out: u64,
 }
 
-/// Instruction builder for `BurnWithdrawTicket`.
+/// Instruction builder for `BurnWithdrawalTicket`.
 ///
 /// ### Accounts:
 ///
@@ -156,7 +156,7 @@ pub struct BurnWithdrawTicketInstructionArgs {
 ///   10. `[optional]` system_program (default to `11111111111111111111111111111111`)
 ///   11. `[signer, optional]` burn_signer
 #[derive(Clone, Debug, Default)]
-pub struct BurnWithdrawTicketBuilder {
+pub struct BurnWithdrawalTicketBuilder {
     config: Option<solana_program::pubkey::Pubkey>,
     vault: Option<solana_program::pubkey::Pubkey>,
     vault_token_account: Option<solana_program::pubkey::Pubkey>,
@@ -173,7 +173,7 @@ pub struct BurnWithdrawTicketBuilder {
     __remaining_accounts: Vec<solana_program::instruction::AccountMeta>,
 }
 
-impl BurnWithdrawTicketBuilder {
+impl BurnWithdrawalTicketBuilder {
     pub fn new() -> Self {
         Self::default()
     }
@@ -285,7 +285,7 @@ impl BurnWithdrawTicketBuilder {
     }
     #[allow(clippy::clone_on_copy)]
     pub fn instruction(&self) -> solana_program::instruction::Instruction {
-        let accounts = BurnWithdrawTicket {
+        let accounts = BurnWithdrawalTicket {
             config: self.config.expect("config is not set"),
             vault: self.vault.expect("vault is not set"),
             vault_token_account: self
@@ -313,7 +313,7 @@ impl BurnWithdrawTicketBuilder {
                 .unwrap_or(solana_program::pubkey!("11111111111111111111111111111111")),
             burn_signer: self.burn_signer,
         };
-        let args = BurnWithdrawTicketInstructionArgs {
+        let args = BurnWithdrawalTicketInstructionArgs {
             min_amount_out: self
                 .min_amount_out
                 .clone()
@@ -324,8 +324,8 @@ impl BurnWithdrawTicketBuilder {
     }
 }
 
-/// `burn_withdraw_ticket` CPI accounts.
-pub struct BurnWithdrawTicketCpiAccounts<'a, 'b> {
+/// `burn_withdrawal_ticket` CPI accounts.
+pub struct BurnWithdrawalTicketCpiAccounts<'a, 'b> {
     pub config: &'b solana_program::account_info::AccountInfo<'a>,
 
     pub vault: &'b solana_program::account_info::AccountInfo<'a>,
@@ -352,8 +352,8 @@ pub struct BurnWithdrawTicketCpiAccounts<'a, 'b> {
     pub burn_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
 }
 
-/// `burn_withdraw_ticket` CPI instruction.
-pub struct BurnWithdrawTicketCpi<'a, 'b> {
+/// `burn_withdrawal_ticket` CPI instruction.
+pub struct BurnWithdrawalTicketCpi<'a, 'b> {
     /// The program to invoke.
     pub __program: &'b solana_program::account_info::AccountInfo<'a>,
 
@@ -382,14 +382,14 @@ pub struct BurnWithdrawTicketCpi<'a, 'b> {
     /// Signer for burning
     pub burn_signer: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     /// The arguments for the instruction.
-    pub __args: BurnWithdrawTicketInstructionArgs,
+    pub __args: BurnWithdrawalTicketInstructionArgs,
 }
 
-impl<'a, 'b> BurnWithdrawTicketCpi<'a, 'b> {
+impl<'a, 'b> BurnWithdrawalTicketCpi<'a, 'b> {
     pub fn new(
         program: &'b solana_program::account_info::AccountInfo<'a>,
-        accounts: BurnWithdrawTicketCpiAccounts<'a, 'b>,
-        args: BurnWithdrawTicketInstructionArgs,
+        accounts: BurnWithdrawalTicketCpiAccounts<'a, 'b>,
+        args: BurnWithdrawalTicketInstructionArgs,
     ) -> Self {
         Self {
             __program: program,
@@ -505,7 +505,7 @@ impl<'a, 'b> BurnWithdrawTicketCpi<'a, 'b> {
                 is_writable: remaining_account.2,
             })
         });
-        let mut data = BurnWithdrawTicketInstructionData::new()
+        let mut data = BurnWithdrawalTicketInstructionData::new()
             .try_to_vec()
             .unwrap();
         let mut args = self.__args.try_to_vec().unwrap();
@@ -544,7 +544,7 @@ impl<'a, 'b> BurnWithdrawTicketCpi<'a, 'b> {
     }
 }
 
-/// Instruction builder for `BurnWithdrawTicket` via CPI.
+/// Instruction builder for `BurnWithdrawalTicket` via CPI.
 ///
 /// ### Accounts:
 ///
@@ -561,13 +561,13 @@ impl<'a, 'b> BurnWithdrawTicketCpi<'a, 'b> {
 ///   10. `[]` system_program
 ///   11. `[signer, optional]` burn_signer
 #[derive(Clone, Debug)]
-pub struct BurnWithdrawTicketCpiBuilder<'a, 'b> {
-    instruction: Box<BurnWithdrawTicketCpiBuilderInstruction<'a, 'b>>,
+pub struct BurnWithdrawalTicketCpiBuilder<'a, 'b> {
+    instruction: Box<BurnWithdrawalTicketCpiBuilderInstruction<'a, 'b>>,
 }
 
-impl<'a, 'b> BurnWithdrawTicketCpiBuilder<'a, 'b> {
+impl<'a, 'b> BurnWithdrawalTicketCpiBuilder<'a, 'b> {
     pub fn new(program: &'b solana_program::account_info::AccountInfo<'a>) -> Self {
-        let instruction = Box::new(BurnWithdrawTicketCpiBuilderInstruction {
+        let instruction = Box::new(BurnWithdrawalTicketCpiBuilderInstruction {
             __program: program,
             config: None,
             vault: None,
@@ -731,14 +731,14 @@ impl<'a, 'b> BurnWithdrawTicketCpiBuilder<'a, 'b> {
         &self,
         signers_seeds: &[&[&[u8]]],
     ) -> solana_program::entrypoint::ProgramResult {
-        let args = BurnWithdrawTicketInstructionArgs {
+        let args = BurnWithdrawalTicketInstructionArgs {
             min_amount_out: self
                 .instruction
                 .min_amount_out
                 .clone()
                 .expect("min_amount_out is not set"),
         };
-        let instruction = BurnWithdrawTicketCpi {
+        let instruction = BurnWithdrawalTicketCpi {
             __program: self.instruction.__program,
 
             config: self.instruction.config.expect("config is not set"),
@@ -795,7 +795,7 @@ impl<'a, 'b> BurnWithdrawTicketCpiBuilder<'a, 'b> {
 }
 
 #[derive(Clone, Debug)]
-struct BurnWithdrawTicketCpiBuilderInstruction<'a, 'b> {
+struct BurnWithdrawalTicketCpiBuilderInstruction<'a, 'b> {
     __program: &'b solana_program::account_info::AccountInfo<'a>,
     config: Option<&'b solana_program::account_info::AccountInfo<'a>>,
     vault: Option<&'b solana_program::account_info::AccountInfo<'a>>,

--- a/clients/rust/vault_client/src/generated/instructions/mod.rs
+++ b/clients/rust/vault_client/src/generated/instructions/mod.rs
@@ -6,7 +6,7 @@
 
 pub(crate) mod r#add_delegation;
 pub(crate) mod r#burn;
-pub(crate) mod r#burn_withdraw_ticket;
+pub(crate) mod r#burn_withdrawal_ticket;
 pub(crate) mod r#change_withdrawal_ticket_owner;
 pub(crate) mod r#close_vault_update_state_tracker;
 pub(crate) mod r#cooldown_delegation;
@@ -36,11 +36,12 @@ pub(crate) mod r#warmup_vault_ncn_slasher_ticket;
 pub(crate) mod r#warmup_vault_ncn_ticket;
 
 pub use self::{
-    r#add_delegation::*, r#burn::*, r#burn_withdraw_ticket::*, r#change_withdrawal_ticket_owner::*,
-    r#close_vault_update_state_tracker::*, r#cooldown_delegation::*,
-    r#cooldown_vault_ncn_slasher_ticket::*, r#cooldown_vault_ncn_ticket::*,
-    r#crank_vault_update_state_tracker::*, r#create_token_metadata::*, r#delegate_token_account::*,
-    r#enqueue_withdrawal::*, r#initialize_config::*, r#initialize_vault::*,
+    r#add_delegation::*, r#burn::*, r#burn_withdrawal_ticket::*,
+    r#change_withdrawal_ticket_owner::*, r#close_vault_update_state_tracker::*,
+    r#cooldown_delegation::*, r#cooldown_vault_ncn_slasher_ticket::*,
+    r#cooldown_vault_ncn_ticket::*, r#crank_vault_update_state_tracker::*,
+    r#create_token_metadata::*, r#delegate_token_account::*, r#enqueue_withdrawal::*,
+    r#initialize_config::*, r#initialize_vault::*,
     r#initialize_vault_ncn_slasher_operator_ticket::*, r#initialize_vault_ncn_slasher_ticket::*,
     r#initialize_vault_ncn_ticket::*, r#initialize_vault_operator_delegation::*,
     r#initialize_vault_update_state_tracker::*, r#initialize_vault_with_mint::*, r#mint_to::*,

--- a/docs/_tools/00_cli.md
+++ b/docs/_tools/00_cli.md
@@ -210,13 +210,13 @@ Vault commands
 
 Initializes the vault
 
-**Usage:** `jito-restaking-cli vault vault initialize <TOKEN_MINT> <DEPOSIT_FEE_BPS> <WITHDRAWAL_FEE_BPS> <REWARD_FEE_BPS> <DECIMALS>`
+**Usage:** `jito-restaking-cli vault vault initialize <TOKEN_MINT> <DEPOSIT_FEE_BPS> <WITHDRAWALAL_FEE_BPS> <REWARD_FEE_BPS> <DECIMALS>`
 
 ###### **Arguments:**
 
 * `<TOKEN_MINT>` — The token which is allowed to be deposited into the vault
 * `<DEPOSIT_FEE_BPS>` — The deposit fee in bips
-* `<WITHDRAWAL_FEE_BPS>` — The withdrawal fee in bips
+* `<WITHDRAWALAL_FEE_BPS>` — The withdrawal fee in bips
 * `<REWARD_FEE_BPS>` — The reward fee in bips
 * `<DECIMALS>` — The decimals of the token
 

--- a/docs/_tools/00_cli.md
+++ b/docs/_tools/00_cli.md
@@ -210,13 +210,13 @@ Vault commands
 
 Initializes the vault
 
-**Usage:** `jito-restaking-cli vault vault initialize <TOKEN_MINT> <DEPOSIT_FEE_BPS> <WITHDRAWALAL_FEE_BPS> <REWARD_FEE_BPS> <DECIMALS>`
+**Usage:** `jito-restaking-cli vault vault initialize <TOKEN_MINT> <DEPOSIT_FEE_BPS> <WITHDRAWAL_FEE_BPS> <REWARD_FEE_BPS> <DECIMALS>`
 
 ###### **Arguments:**
 
 * `<TOKEN_MINT>` — The token which is allowed to be deposited into the vault
 * `<DEPOSIT_FEE_BPS>` — The deposit fee in bips
-* `<WITHDRAWALAL_FEE_BPS>` — The withdrawal fee in bips
+* `<WITHDRAWAL_FEE_BPS>` — The withdrawal fee in bips
 * `<REWARD_FEE_BPS>` — The reward fee in bips
 * `<DECIMALS>` — The decimals of the token
 

--- a/docs/_vault/01_vault_theory_of_operation.md
+++ b/docs/_vault/01_vault_theory_of_operation.md
@@ -217,7 +217,7 @@ The withdrawal enqueueing process is a crucial part of the vault's operation, al
 Key points:
 - The vault keeps track of all the enqueued withdrawals in `vrt_enqueued_for_cooldown_amount`, `vrt_cooling_down_amount` and `vrt_ready_to_claim_amount` amounts. This is a safeguard to ensure the vault can meet its withdrawal obligations.
 - Withdrawals are not immediately available for withdrawal. They must complete the cooldown period of one full epoch before they can be withdrawn.
-- Anyone can complete the withdrawal process by calling the `BurnWithdrawTicket` instruction.
+- Anyone can complete the withdrawal process by calling the `BurnWithdrawalTicket` instruction.
   - This ensures that squatters can't prevent delegation by holding VRTs that can be withdrawn but aren't.
 - The amount of VRTs cooling down is tracked in `vrt_cooling_down_amount`, as opposed to assets equal to the redemption price at the time of withdrawal. This is because the redemption price at the time of withdrawal is unknown at the time of enqueuing. This attempts to guarantee that the vault can meet its withdrawal obligations even if the redemption price at the time of withdrawal is lower than the redemption price at the time of enqueuing.
 

--- a/docs/_vault/01_vault_theory_of_operation.md
+++ b/docs/_vault/01_vault_theory_of_operation.md
@@ -45,7 +45,7 @@ Here's a list of different admins that control the vault:
 - `slasher_admin`: Add and removal of slashers.
 - `capacity_admin`: Set the vault's max token capacity.
 - `fee_admin`: Set and adjust deposit, withdrawal, and reward fees.
-- `withdraw_admin`: Initiate token withdrawals from the vault.
+- `withdrawal_admin`: Initiate token withdrawals from the vault.
 - `mint_burn_admin`: An optional admin for minting and burning operations.
 
 # 4. Vault Configuration

--- a/idl/jito_vault.json
+++ b/idl/jito_vault.json
@@ -724,7 +724,7 @@
       }
     },
     {
-      "name": "BurnWithdrawTicket",
+      "name": "BurnWithdrawalTicket",
       "accounts": [
         {
           "name": "config",

--- a/integration_tests/tests/fixtures/fixture.rs
+++ b/integration_tests/tests/fixtures/fixture.rs
@@ -340,7 +340,7 @@ impl TestBuilder {
     pub async fn setup_vault_with_ncn_and_operators(
         &mut self,
         deposit_fee_bps: u16,
-        withdraw_fee_bps: u16,
+        withdrawal_fee_bps: u16,
         reward_fee_bps: u16,
         num_operators: u16,
         slasher_amounts: &[u64],
@@ -349,7 +349,7 @@ impl TestBuilder {
         let mut restaking_program_client = self.restaking_program_client();
 
         let (vault_config_admin, vault_root) = vault_program_client
-            .setup_config_and_vault(deposit_fee_bps, withdraw_fee_bps, reward_fee_bps)
+            .setup_config_and_vault(deposit_fee_bps, withdrawal_fee_bps, reward_fee_bps)
             .await?;
         let restaking_config_admin = restaking_program_client.do_initialize_config().await?;
 

--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -261,12 +261,12 @@ impl VaultProgramClient {
     pub async fn setup_config_and_vault(
         &mut self,
         deposit_fee_bps: u16,
-        withdraw_fee_bps: u16,
+        withdrawal_fee_bps: u16,
         reward_fee_bps: u16,
     ) -> Result<(Keypair, VaultRoot), TestError> {
         let config_admin = self.do_initialize_config().await?;
         let vault_root = self
-            .do_initialize_vault(deposit_fee_bps, withdraw_fee_bps, reward_fee_bps, 9)
+            .do_initialize_vault(deposit_fee_bps, withdrawal_fee_bps, reward_fee_bps, 9)
             .await?;
 
         Ok((config_admin, vault_root))
@@ -275,7 +275,7 @@ impl VaultProgramClient {
     pub async fn do_initialize_vault(
         &mut self,
         deposit_fee_bps: u16,
-        withdraw_fee_bps: u16,
+        withdrawal_fee_bps: u16,
         reward_fee_bps: u16,
         decimals: u8,
     ) -> Result<VaultRoot, TestError> {
@@ -300,7 +300,7 @@ impl VaultProgramClient {
             &vault_admin,
             &vault_base,
             deposit_fee_bps,
-            withdraw_fee_bps,
+            withdrawal_fee_bps,
             reward_fee_bps,
             decimals,
         )
@@ -912,7 +912,7 @@ impl VaultProgramClient {
         .await
     }
 
-    pub async fn do_enqueue_withdraw(
+    pub async fn do_enqueue_withdrawal(
         &mut self,
         vault_root: &VaultRoot,
         depositor: &Keypair,
@@ -939,7 +939,7 @@ impl VaultProgramClient {
         self.create_ata(&vault.vrt_mint, &vault_staker_withdrawal_ticket)
             .await?;
 
-        self.enqueue_withdraw(
+        self.enqueue_withdrawal(
             &Config::find_program_address(&jito_vault_program::id()).0,
             &vault_root.vault_pubkey,
             &vault_staker_withdrawal_ticket,
@@ -1179,7 +1179,7 @@ impl VaultProgramClient {
         .await
     }
 
-    pub async fn enqueue_withdraw(
+    pub async fn enqueue_withdrawal(
         &mut self,
         config: &Pubkey,
         vault: &Pubkey,
@@ -1192,7 +1192,7 @@ impl VaultProgramClient {
     ) -> Result<(), TestError> {
         let blockhash = self.banks_client.get_latest_blockhash().await?;
         self._process_transaction(&Transaction::new_signed_with_payer(
-            &[jito_vault_sdk::sdk::enqueue_withdraw(
+            &[jito_vault_sdk::sdk::enqueue_withdrawal(
                 &jito_vault_program::id(),
                 config,
                 vault,

--- a/integration_tests/tests/vault/add_delegation.rs
+++ b/integration_tests/tests/vault/add_delegation.rs
@@ -15,7 +15,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -28,7 +28,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -91,7 +91,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -104,7 +104,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/burn_withdrawal_ticket.rs
+++ b/integration_tests/tests/vault/burn_withdrawal_ticket.rs
@@ -20,7 +20,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -38,7 +38,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -81,7 +81,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 
@@ -100,7 +100,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -118,7 +118,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 
@@ -196,7 +196,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -214,7 +214,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -257,7 +257,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 
@@ -321,7 +321,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -339,7 +339,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -387,7 +387,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 
@@ -465,7 +465,7 @@ mod tests {
         const MIN_AMOUNT_OUT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -483,7 +483,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -503,7 +503,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/burn_withdrawal_ticket.rs
+++ b/integration_tests/tests/vault/burn_withdrawal_ticket.rs
@@ -14,7 +14,7 @@ mod tests {
         vault_client::{assert_vault_error, VaultStakerWithdrawalTicketRoot},
     };
 
-    /// One can't burn the withdraw ticket until a full epoch has passed
+    /// One can't burn the withdrawal ticket until a full epoch has passed
     #[tokio::test]
     async fn test_burn_withdrawal_ticket_same_epoch_fails() {
         const MINT_AMOUNT: u64 = 100_000;
@@ -94,7 +94,7 @@ mod tests {
         );
     }
 
-    /// One can't burn the withdraw ticket until a full epoch has passed
+    /// One can't burn the withdrawal ticket until a full epoch has passed
     #[tokio::test]
     async fn test_burn_withdrawal_ticket_next_epoch_fails() {
         const MINT_AMOUNT: u64 = 100_000;
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 
@@ -190,13 +190,13 @@ mod tests {
         );
     }
 
-    /// Tests basic withdraw ticket with no rewards or slashing incidents
+    /// Tests basic withdrawal ticket with no rewards or slashing incidents
     #[tokio::test]
     async fn test_burn_withdrawal_ticket_basic_success() {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdrawal_fee_bps = 0;
+        let withdraw_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -214,7 +214,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdrawal_fee_bps,
+                withdraw_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -315,13 +315,13 @@ mod tests {
         assert_eq!(depositor_token_account.amount, MINT_AMOUNT);
     }
 
-    /// Tests basic withdraw ticket with no rewards or slashing incidents
+    /// Tests basic withdrawal ticket with no rewards or slashing incidents
     #[tokio::test]
     async fn test_burn_withdrawal_ticket_slippage_fails() {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdrawal_fee_bps = 0;
+        let withdraw_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -339,7 +339,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdrawal_fee_bps,
+                withdraw_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/burn_withdrawal_ticket.rs
+++ b/integration_tests/tests/vault/burn_withdrawal_ticket.rs
@@ -161,7 +161,7 @@ mod tests {
             .unwrap();
 
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, MINT_AMOUNT)
+            .do_enqueue_withdrawal(&vault_root, &depositor, MINT_AMOUNT)
             .await
             .unwrap();
 

--- a/integration_tests/tests/vault/close_update_state_tracker.rs
+++ b/integration_tests/tests/vault/close_update_state_tracker.rs
@@ -14,7 +14,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 0;
         let slasher_amounts = vec![];
@@ -26,7 +26,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -79,7 +79,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -92,7 +92,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -155,7 +155,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -168,7 +168,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -251,7 +251,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -264,7 +264,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -287,7 +287,7 @@ mod tests {
             .await
             .unwrap();
         let VaultStakerWithdrawalTicketRoot { base: _ } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, 100_000)
+            .do_enqueue_withdrawal(&vault_root, &depositor, 100_000)
             .await
             .unwrap();
         let vault = vault_program_client

--- a/integration_tests/tests/vault/cooldown_delegation.rs
+++ b/integration_tests/tests/vault/cooldown_delegation.rs
@@ -14,7 +14,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -27,7 +27,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -58,7 +58,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -71,7 +71,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -105,7 +105,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -118,7 +118,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -162,7 +162,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -175,7 +175,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -244,7 +244,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -257,7 +257,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/crank_vault_update_state_tracker.rs
+++ b/integration_tests/tests/vault/crank_vault_update_state_tracker.rs
@@ -17,7 +17,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -30,7 +30,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -128,7 +128,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -141,7 +141,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -234,7 +234,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -247,7 +247,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -324,7 +324,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -337,7 +337,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -404,7 +404,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 3;
         let slasher_amounts = vec![];
@@ -417,7 +417,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -492,7 +492,7 @@ mod tests {
         let mut fixture = TestBuilder::new().await;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 2;
         let slasher_amounts = vec![];
@@ -505,7 +505,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/enqueue_withdrawal.rs
+++ b/integration_tests/tests/vault/enqueue_withdrawal.rs
@@ -14,11 +14,11 @@ mod tests {
     async fn test_enqueue_withdrawal_with_fee_success() {
         const MINT_AMOUNT: u64 = 100_000;
         const DEPOSIT_FEE_BPS: u16 = 100;
-        const withdrawal_FEE_BPS: u16 = 100;
+        const WITHDRAWAL_FEE_BPS: u16 = 100;
         let min_amount_out: u64 = MINT_AMOUNT * (10_000 - DEPOSIT_FEE_BPS) as u64 / 10_000;
 
         let deposit_fee_bps = DEPOSIT_FEE_BPS;
-        let withdrawal_fee_bps = withdrawal_FEE_BPS;
+        let withdrawal_fee_bps = WITHDRAWAL_FEE_BPS;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -115,7 +115,7 @@ mod tests {
 
         // the user is withdrawing 99,000 VRT tokens, there is a 1% fee on withdraws, so
         // 98010 tokens will be undeleged for withdraw
-        let amount_to_dequeue = MINT_AMOUNT * (10_000 - withdrawal_FEE_BPS) as u64 / 10_000;
+        let amount_to_dequeue = MINT_AMOUNT * (10_000 - WITHDRAWAL_FEE_BPS) as u64 / 10_000;
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
             .do_enqueue_withdrawal(&vault_root, &depositor, amount_to_dequeue)
             .await

--- a/integration_tests/tests/vault/enqueue_withdrawal.rs
+++ b/integration_tests/tests/vault/enqueue_withdrawal.rs
@@ -11,14 +11,14 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn test_enqueue_withdraw_with_fee_success() {
+    async fn test_enqueue_withdrawal_with_fee_success() {
         const MINT_AMOUNT: u64 = 100_000;
         const DEPOSIT_FEE_BPS: u16 = 100;
-        const WITHDRAW_FEE_BPS: u16 = 100;
+        const withdrawal_FEE_BPS: u16 = 100;
         let min_amount_out: u64 = MINT_AMOUNT * (10_000 - DEPOSIT_FEE_BPS) as u64 / 10_000;
 
         let deposit_fee_bps = DEPOSIT_FEE_BPS;
-        let withdraw_fee_bps = WITHDRAW_FEE_BPS;
+        let withdrawal_fee_bps = withdrawal_FEE_BPS;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -32,7 +32,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -115,9 +115,9 @@ mod tests {
 
         // the user is withdrawing 99,000 VRT tokens, there is a 1% fee on withdraws, so
         // 98010 tokens will be undeleged for withdraw
-        let amount_to_dequeue = MINT_AMOUNT * (10_000 - WITHDRAW_FEE_BPS) as u64 / 10_000;
+        let amount_to_dequeue = MINT_AMOUNT * (10_000 - withdrawal_FEE_BPS) as u64 / 10_000;
         let VaultStakerWithdrawalTicketRoot { base } = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, amount_to_dequeue)
+            .do_enqueue_withdrawal(&vault_root, &depositor, amount_to_dequeue)
             .await
             .unwrap();
 
@@ -142,7 +142,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_enqueue_withdraw_zero_fails() {
+    async fn test_enqueue_withdrawal_zero_fails() {
         let mut fixture = TestBuilder::new().await;
         let ConfiguredVault {
             mut vault_program_client,
@@ -184,7 +184,7 @@ mod tests {
             .unwrap();
 
         let err = vault_program_client
-            .do_enqueue_withdraw(&vault_root, &depositor, 0)
+            .do_enqueue_withdrawal(&vault_root, &depositor, 0)
             .await;
 
         assert_vault_error(err, VaultError::VaultEnqueueWithdrawalAmountZero);

--- a/integration_tests/tests/vault/reward_fee.rs
+++ b/integration_tests/tests/vault/reward_fee.rs
@@ -12,7 +12,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 1000; // 10%
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -25,7 +25,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -82,7 +82,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 10_000; // 100%
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -95,7 +95,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -152,7 +152,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0; // 0%
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -165,7 +165,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,
@@ -222,7 +222,7 @@ mod tests {
         const MINT_AMOUNT: u64 = 100_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 1000; // 10%
         let num_operators = 1;
         let slasher_amounts = vec![];
@@ -235,7 +235,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/set_fees.rs
+++ b/integration_tests/tests/vault/set_fees.rs
@@ -885,7 +885,7 @@ mod tests {
         assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
         assert_eq!(updated_vault.reward_fee_bps(), reward_fee_bps);
 
-        let new_withdraw_fee_bps = withdrawal_fee_bps + 1;
+        let new_withdrawal_fee_bps = withdrawal_fee_bps + 1;
 
         fixture
             .warp_slot_incremental(config.epoch_length() * 2)
@@ -899,7 +899,7 @@ mod tests {
                 &vault_pubkey,
                 &vault_admin,
                 None,
-                Some(new_withdraw_fee_bps),
+                Some(new_withdrawal_fee_bps),
                 None,
             )
             .await
@@ -911,7 +911,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdraw_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(updated_vault.reward_fee_bps(), reward_fee_bps);
 
         let new_reward_fee_bps = reward_fee_bps + 1;
@@ -940,7 +940,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdraw_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(updated_vault.reward_fee_bps(), new_reward_fee_bps);
     }
 

--- a/integration_tests/tests/vault/set_secondary_admin.rs
+++ b/integration_tests/tests/vault/set_secondary_admin.rs
@@ -229,7 +229,7 @@ mod tests {
         }
 
         {
-            // Withdraw Admin
+            // WithdrawalAdmin
             let new_admin = Pubkey::new_unique();
             vault_program_client
                 .set_secondary_admin(

--- a/integration_tests/tests/vault/slash.rs
+++ b/integration_tests/tests/vault/slash.rs
@@ -17,7 +17,7 @@ mod tests {
         const DELEGATION_AMOUNT: u64 = 10_000;
 
         let deposit_fee_bps = 0;
-        let withdraw_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
         let reward_fee_bps = 0;
         let num_operators = 1;
         let slasher_amounts = vec![MAX_SLASH_AMOUNT];
@@ -33,7 +33,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 deposit_fee_bps,
-                withdraw_fee_bps,
+                withdrawal_fee_bps,
                 reward_fee_bps,
                 num_operators,
                 &slasher_amounts,

--- a/integration_tests/tests/vault/update_vault_balance.rs
+++ b/integration_tests/tests/vault/update_vault_balance.rs
@@ -13,7 +13,7 @@ mod tests {
 
     const MINT_AMOUNT: u64 = 100_000;
     const DEPOSIT_FEE_BPS: u16 = 0;
-    const WITHDRAW_FEE_BPS: u16 = 0;
+    const WITHDRAWAL_FEE_BPS: u16 = 0;
     const REWARD_FEE_BPS: u16 = 1000; // 10%
 
     async fn setup() -> (TestBuilder, VaultRoot) {
@@ -33,7 +33,7 @@ mod tests {
         } = fixture
             .setup_vault_with_ncn_and_operators(
                 DEPOSIT_FEE_BPS,
-                WITHDRAW_FEE_BPS,
+                WITHDRAWAL_FEE_BPS,
                 REWARD_FEE_BPS,
                 num_operators,
                 &slasher_amounts,

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -726,7 +726,7 @@ impl Vault {
     }
 
     /// Calculate the amount of tokens collected as a fee for withdrawing tokens from the vault.
-    fn calculate_withdraw_fee(&self, vrt_amount: u64) -> Result<u64, VaultError> {
+    fn calculate_withdrawal_fee(&self, vrt_amount: u64) -> Result<u64, VaultError> {
         let fee = (vrt_amount as u128)
             .checked_mul(self.withdrawal_fee_bps() as u128)
             .map(|x| x.div_ceil(MAX_FEE_BPS as u128))
@@ -795,7 +795,7 @@ impl Vault {
             return Err(VaultError::VaultInsufficientFunds);
         }
 
-        let fee_amount = self.calculate_withdraw_fee(amount_in)?;
+        let fee_amount = self.calculate_withdrawal_fee(amount_in)?;
         let amount_to_burn = amount_in
             .checked_sub(fee_amount)
             .ok_or(VaultError::VaultUnderflow)?;
@@ -858,7 +858,7 @@ impl Vault {
             .and_then(|x| x.checked_add(self.vrt_ready_to_claim_amount()))
             .ok_or(VaultError::VaultOverflow)?;
 
-        let fee_amount = self.calculate_withdraw_fee(vrt_reserve)?;
+        let fee_amount = self.calculate_withdrawal_fee(vrt_reserve)?;
 
         let vrt_reserve_with_fee = vrt_reserve
             .checked_add(fee_amount)
@@ -1058,7 +1058,7 @@ mod tests {
 
     fn make_test_vault(
         deposit_fee_bps: u16,
-        withdraw_fee_bps: u16,
+        withdrawal_fee_bps: u16,
         tokens_deposited: u64,
         vrt_supply: u64,
         delegation_state: DelegationState,
@@ -1070,7 +1070,7 @@ mod tests {
             0,
             Pubkey::new_unique(),
             deposit_fee_bps,
-            withdraw_fee_bps,
+            withdrawal_fee_bps,
             0,
             0,
             0,

--- a/vault_core/src/vault_operator_delegation.rs
+++ b/vault_core/src/vault_operator_delegation.rs
@@ -72,8 +72,8 @@ impl VaultOperatorDelegation {
     /// Updates the state of the delegation
     /// The cooling_down_amount becomes the enqueued_for_cooldown_amount
     /// The enqueued_for_cooldown_amount is zeroed out
-    /// The cooling_down_for_withdraw_amount becomes the enqueued_for_withdraw_amount
-    /// The enqueued_for_withdraw_amount is zeroed out
+    /// The cooling_down_for_withdrawal_amount becomes the enqueued_for_withdrawal_amount
+    /// The enqueued_for_withdrawal_amount is zeroed out
     #[inline(always)]
     pub fn update(&mut self, slot: u64, epoch_length: u64) {
         let last_update_epoch = self.last_update_slot().checked_div(epoch_length).unwrap();

--- a/vault_core/src/vault_staker_withdrawal_ticket.rs
+++ b/vault_core/src/vault_staker_withdrawal_ticket.rs
@@ -11,7 +11,7 @@ impl Discriminator for VaultStakerWithdrawalTicket {
 }
 
 /// The [`VaultStakerWithdrawalTicket`] account is used to represent a pending withdrawal from a vault by a staker.
-/// For every withdraw ticket, there's an associated token account owned by the withdrawal ticket with the staker's VRT.
+/// For every withdrawal ticket, there's an associated token account owned by the withdrawal ticket with the staker's VRT.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Pod, Zeroable, AccountDeserialize, ShankAccount)]
 #[repr(C)]
 pub struct VaultStakerWithdrawalTicket {
@@ -144,26 +144,26 @@ impl VaultStakerWithdrawalTicket {
         expect_writable: bool,
     ) -> Result<(), ProgramError> {
         if vault_staker_withdrawal_ticket.owner.ne(program_id) {
-            msg!("Vault staker withdraw ticket has an invalid owner");
+            msg!("Vault staker withdrawal ticket has an invalid owner");
             return Err(ProgramError::InvalidAccountOwner);
         }
         if vault_staker_withdrawal_ticket.data_is_empty() {
-            msg!("Vault staker withdraw ticket data is empty");
+            msg!("Vault staker withdrawal ticket data is empty");
             return Err(ProgramError::InvalidAccountData);
         }
         if expect_writable && !vault_staker_withdrawal_ticket.is_writable {
-            msg!("Vault staker withdraw ticket is not writable");
+            msg!("Vault staker withdrawal ticket is not writable");
             return Err(ProgramError::InvalidAccountData);
         }
         if vault_staker_withdrawal_ticket.data.borrow()[0].ne(&Self::DISCRIMINATOR) {
-            msg!("Vault staker withdraw ticket discriminator is invalid");
+            msg!("Vault staker withdrawal ticket discriminator is invalid");
             return Err(ProgramError::InvalidAccountData);
         }
         let vault_staker_withdrawal_ticket_data = vault_staker_withdrawal_ticket.data.borrow();
         let base = Self::try_from_slice_unchecked(&vault_staker_withdrawal_ticket_data)?.base;
         let expected_pubkey = Self::find_program_address(program_id, vault.key, &base).0;
         if vault_staker_withdrawal_ticket.key.ne(&expected_pubkey) {
-            msg!("Vault staker withdraw ticket is not at the correct PDA");
+            msg!("Vault staker withdrawal ticket is not at the correct PDA");
             return Err(ProgramError::InvalidAccountData);
         }
         Ok(())

--- a/vault_core/src/vault_staker_withdrawal_ticket.rs
+++ b/vault_core/src/vault_staker_withdrawal_ticket.rs
@@ -159,8 +159,8 @@ impl VaultStakerWithdrawalTicket {
             msg!("Vault staker withdraw ticket discriminator is invalid");
             return Err(ProgramError::InvalidAccountData);
         }
-        let vault_staker_withdraw_ticket_data = vault_staker_withdrawal_ticket.data.borrow();
-        let base = Self::try_from_slice_unchecked(&vault_staker_withdraw_ticket_data)?.base;
+        let vault_staker_withdrawal_ticket_data = vault_staker_withdrawal_ticket.data.borrow();
+        let base = Self::try_from_slice_unchecked(&vault_staker_withdrawal_ticket_data)?.base;
         let expected_pubkey = Self::find_program_address(program_id, vault.key, &base).0;
         if vault_staker_withdrawal_ticket.key.ne(&expected_pubkey) {
             msg!("Vault staker withdraw ticket is not at the correct PDA");

--- a/vault_program/src/burn_withdrawal_ticket.rs
+++ b/vault_program/src/burn_withdrawal_ticket.rs
@@ -79,14 +79,14 @@ pub fn process_burn_withdrawal_ticket(
     } = vault.burn_with_fee(vault_staker_withdrawal_ticket.vrt_amount(), min_amount_out)?;
     vault.decrement_vrt_ready_to_claim_amount(vault_staker_withdrawal_ticket.vrt_amount())?;
 
-    let (_, vault_staker_withdraw_bump, mut vault_staker_withdraw_seeds) =
+    let (_, vault_staker_withdrawal_bump, mut vault_staker_withdrawal_seeds) =
         VaultStakerWithdrawalTicket::find_program_address(
             program_id,
             vault_info.key,
             &vault_staker_withdrawal_ticket.base,
         );
-    vault_staker_withdraw_seeds.push(vec![vault_staker_withdraw_bump]);
-    let seed_slices: Vec<&[u8]> = vault_staker_withdraw_seeds
+    vault_staker_withdrawal_seeds.push(vec![vault_staker_withdrawal_bump]);
+    let seed_slices: Vec<&[u8]> = vault_staker_withdrawal_seeds
         .iter()
         .map(|seed| seed.as_slice())
         .collect();

--- a/vault_program/src/enqueue_withdrawal.rs
+++ b/vault_program/src/enqueue_withdrawal.rs
@@ -83,7 +83,7 @@ pub fn process_enqueue_withdrawal(
 
     // Create the VaultStakerWithdrawalTicket account
     msg!(
-        "Initializing vault staker withdraw ticket at address {}",
+        "Initializing vault staker withdrawal ticket at address {}",
         vault_staker_withdrawal_ticket.key
     );
     create_account(

--- a/vault_program/src/lib.rs
+++ b/vault_program/src/lib.rs
@@ -196,8 +196,8 @@ pub fn process_instruction(
             msg!("Instruction: ChangeWithdrawalTicketOwner");
             process_change_withdrawal_ticket_owner(program_id, accounts)
         }
-        VaultInstruction::BurnWithdrawTicket { min_amount_out } => {
-            msg!("Instruction: BurnWithdrawTicket");
+        VaultInstruction::BurnWithdrawalTicket { min_amount_out } => {
+            msg!("Instruction: BurnWithdrawalTicket");
             process_burn_withdrawal_ticket(program_id, accounts, min_amount_out)
         }
         // ------------------------------------------

--- a/vault_sdk/src/instruction.rs
+++ b/vault_sdk/src/instruction.rs
@@ -165,7 +165,7 @@ pub enum VaultInstruction {
     #[account(4, name = "new_owner")]
     ChangeWithdrawalTicketOwner,
 
-    /// Burns the withdraw ticket, returning funds to the staker. Withdraw tickets can be burned
+    /// Burns the withdrawal ticket, returning funds to the staker. Withdraw tickets can be burned
     /// after one full epoch of being enqueued.
     #[account(0, name = "config")]
     #[account(1, writable, name = "vault")]
@@ -179,7 +179,7 @@ pub enum VaultInstruction {
     #[account(9, name = "token_program")]
     #[account(10, name = "system_program")]
     #[account(11, signer, optional, name = "burn_signer", description = "Signer for burning")]
-    BurnWithdrawTicket {
+    BurnWithdrawalTicket {
         min_amount_out: u64
     },
 

--- a/vault_sdk/src/sdk.rs
+++ b/vault_sdk/src/sdk.rs
@@ -657,7 +657,7 @@ pub fn burn_withdrawal_ticket(
     Instruction {
         program_id: *program_id,
         accounts,
-        data: VaultInstruction::BurnWithdrawTicket { min_amount_out }
+        data: VaultInstruction::BurnWithdrawalTicket { min_amount_out }
             .try_to_vec()
             .unwrap(),
     }

--- a/vault_sdk/src/sdk.rs
+++ b/vault_sdk/src/sdk.rs
@@ -596,7 +596,7 @@ pub fn slash(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn enqueue_withdraw(
+pub fn enqueue_withdrawal(
     program_id: &Pubkey,
     config: &Pubkey,
     vault: &Pubkey,


### PR DESCRIPTION
Standardize on withdrawal > withdraw. Withdrawal is the noun, withdraw is the verb, so it works better grammatically for "Withdrawal Ticket" and Withdrawal Fee". Will be much easier for searching for things since there were a number of mismatches on file names / instruction names / functions etc.
