### PR TITLE
Docs: remove the explanation of burn VRT

### DIFF
--- a/docs/_vault/01_vault_theory_of_operation.md
+++ b/docs/_vault/01_vault_theory_of_operation.md
@@ -256,27 +256,7 @@ This last look ensures that the vault remains responsive to withdrawal requests 
 
 # 11. Burning
 
-## 11.1. Burning VRT
-
-Burning is the process of redeeming VRT tokens for the underlying assets in the vault. Here's a high-level overview of the burning process:
-
-1. The user initiates a burn transaction, specifying the amount of VRT to burn and the minimum amount of underlying assets they expect to receive.
-2. The vault performs several checks:
-   - Ensures the VRT mint is correct
-   - Verifies that the vault state doesn't need an update
-   - Checks if a mint burn admin is required and present
-3. The vault calculates the burn summary, which includes:
-   - The fee amount to be collected
-   - The amount of VRT to be burned
-   - The amount of underlying assets to be returned to the user
-4. The specified amount of VRT is burned from the user's account.
-5. The fee amount of VRT is transferred to the vault's fee account.
-6. The calculated amount of underlying assets is transferred from the vault to the user's account.
-7. The vault's internal state is updated to reflect the burn:
-   - The VRT supply is decreased
-   - The total tokens deposited in the vault is reduced
-
-## 11.2. Burning VRT Withdrawal Tickets
+## 11.1. Burning VRT Withdrawal Tickets
 
 Burning a VRT Withdrawal Ticket is the process of finalizing a withdrawal from the vault. VRTs that have been withdrawn for more than one full epoch can be burned to receive the underlying assets.
 


### PR DESCRIPTION
Since #137 has merged, we should also remove the explanation of burn from docs?