### PR TITLE
VAULT: Mint To should fail if depositor gets 0 VRT for any amount of ST

### DIFF
--- a/clients/js/vault_client/errors/jitoVault.ts
+++ b/clients/js/vault_client/errors/jitoVault.ts
@@ -124,6 +124,8 @@ export const JITO_VAULT_ERROR__INVALID_DEPOSIT_TOKEN_ACCOUNT = 0x41c; // 1052
 export const JITO_VAULT_ERROR__NO_SUPPORTED_MINT_BALANCE_CHANGE = 0x41d; // 1053
 /** InvalidEpochLength: InvalidEpochLength */
 export const JITO_VAULT_ERROR__INVALID_EPOCH_LENGTH = 0x41e; // 1054
+/** NoZeroReturnMintTo: NoZeroReturnMintTo */
+export const JITO_VAULT_ERROR__NO_ZERO_RETURN_MINT_TO = 0x41f; // 1055
 /** ArithmeticOverflow: ArithmeticOverflow */
 export const JITO_VAULT_ERROR__ARITHMETIC_OVERFLOW = 0xbb8; // 3000
 /** ArithmeticUnderflow: ArithmeticUnderflow */
@@ -143,6 +145,7 @@ export type JitoVaultError =
   | typeof JITO_VAULT_ERROR__NCN_VAULT_SLASHER_TICKET_UNSLASHABLE
   | typeof JITO_VAULT_ERROR__NCN_VAULT_TICKET_UNSLASHABLE
   | typeof JITO_VAULT_ERROR__NO_SUPPORTED_MINT_BALANCE_CHANGE
+  | typeof JITO_VAULT_ERROR__NO_ZERO_RETURN_MINT_TO
   | typeof JITO_VAULT_ERROR__OPERATOR_OVERFLOW
   | typeof JITO_VAULT_ERROR__OPERATOR_VAULT_TICKET_UNSLASHABLE
   | typeof JITO_VAULT_ERROR__SLASHER_OVERFLOW
@@ -205,6 +208,7 @@ if (process.env.NODE_ENV !== 'production') {
     [JITO_VAULT_ERROR__NCN_VAULT_SLASHER_TICKET_UNSLASHABLE]: `NcnVaultSlasherTicketUnslashable`,
     [JITO_VAULT_ERROR__NCN_VAULT_TICKET_UNSLASHABLE]: `NcnVaultTicketUnslashable`,
     [JITO_VAULT_ERROR__NO_SUPPORTED_MINT_BALANCE_CHANGE]: `NoSupportedMintBalanceChange`,
+    [JITO_VAULT_ERROR__NO_ZERO_RETURN_MINT_TO]: `NoZeroReturnMintTo`,
     [JITO_VAULT_ERROR__OPERATOR_OVERFLOW]: `OperatorOverflow`,
     [JITO_VAULT_ERROR__OPERATOR_VAULT_TICKET_UNSLASHABLE]: `OperatorVaultTicketUnslashable`,
     [JITO_VAULT_ERROR__SLASHER_OVERFLOW]: `SlasherOverflow`,

--- a/clients/rust/vault_client/src/generated/errors/jito_vault.rs
+++ b/clients/rust/vault_client/src/generated/errors/jito_vault.rs
@@ -174,6 +174,9 @@ pub enum JitoVaultError {
     /// 1054 - InvalidEpochLength
     #[error("InvalidEpochLength")]
     InvalidEpochLength = 0x41E,
+    /// 1055 - NoZeroReturnMintTo
+    #[error("NoZeroReturnMintTo")]
+    NoZeroReturnMintTo = 0x41F,
     /// 3000 - ArithmeticOverflow
     #[error("ArithmeticOverflow")]
     ArithmeticOverflow = 0xBB8,

--- a/idl/jito_vault.json
+++ b/idl/jito_vault.json
@@ -2457,6 +2457,11 @@
       "msg": "InvalidEpochLength"
     },
     {
+      "code": 1055,
+      "name": "NoZeroReturnMintTo",
+      "msg": "NoZeroReturnMintTo"
+    },
+    {
       "code": 3000,
       "name": "ArithmeticOverflow",
       "msg": "ArithmeticOverflow"

--- a/vault_program/src/mint_to.rs
+++ b/vault_program/src/mint_to.rs
@@ -92,6 +92,11 @@ pub fn process_mint(
         vrt_to_fee_wallet,
     } = vault.mint_with_fee(amount_in, min_amount_out)?;
 
+    if vrt_to_depositor == 0 {
+        msg!("Depositor will not receive any VRT");
+        return Err(VaultError::NoZeroReturnMintTo.into());
+    }
+
     // transfer tokens from depositor to vault
     {
         invoke(

--- a/vault_sdk/src/error.rs
+++ b/vault_sdk/src/error.rs
@@ -113,6 +113,8 @@ pub enum VaultError {
     NoSupportedMintBalanceChange,
     #[error("InvalidEpochLength")]
     InvalidEpochLength,
+    #[error("NoZeroReturnMintTo")]
+    NoZeroReturnMintTo,
 
     #[error("ArithmeticOverflow")]
     ArithmeticOverflow = 3000,


### PR DESCRIPTION
There are scenarios, like front running an initial deposit, where a depositor can received 0 VRT given some ST deposit. This should never be the case. This is in addition to `min_amount_out`.