### PR TITLE
Vault: Only apply fee changes at start of vault update

### DIFF
--- a/clients/js/vault_client/accounts/vault.ts
+++ b/clients/js/vault_client/accounts/vault.ts
@@ -77,7 +77,9 @@ export type Vault = {
   lastFullStateUpdateSlot: bigint;
   depositFeeBps: number;
   withdrawalFeeBps: number;
+  nextWithdrawalFeeBps: number;
   rewardFeeBps: number;
+  programFeeBps: number;
   bump: number;
   isPaused: number;
   reserved: Array<number>;
@@ -115,7 +117,9 @@ export type VaultArgs = {
   lastFullStateUpdateSlot: number | bigint;
   depositFeeBps: number;
   withdrawalFeeBps: number;
+  nextWithdrawalFeeBps: number;
   rewardFeeBps: number;
+  programFeeBps: number;
   bump: number;
   isPaused: number;
   reserved: Array<number>;
@@ -154,10 +158,12 @@ export function getVaultEncoder(): Encoder<VaultArgs> {
     ['lastFullStateUpdateSlot', getU64Encoder()],
     ['depositFeeBps', getU16Encoder()],
     ['withdrawalFeeBps', getU16Encoder()],
+    ['nextWithdrawalFeeBps', getU16Encoder()],
     ['rewardFeeBps', getU16Encoder()],
+    ['programFeeBps', getU16Encoder()],
     ['bump', getU8Encoder()],
     ['isPaused', getBoolEncoder()],
-    ['reserved', getArrayEncoder(getU8Encoder(), { size: 263 })],
+    ['reserved', getArrayEncoder(getU8Encoder(), { size: 259 })],
   ]);
 }
 
@@ -194,10 +200,12 @@ export function getVaultDecoder(): Decoder<Vault> {
     ['lastFullStateUpdateSlot', getU64Decoder()],
     ['depositFeeBps', getU16Decoder()],
     ['withdrawalFeeBps', getU16Decoder()],
+    ['nextWithdrawalFeeBps', getU16Decoder()],
     ['rewardFeeBps', getU16Decoder()],
+    ['programFeeBps', getU16Decoder()],
     ['bump', getU8Decoder()],
     ['isPaused', getBoolDecoder()],
-    ['reserved', getArrayDecoder(getU8Decoder(), { size: 263 })],
+    ['reserved', getArrayDecoder(getU8Decoder(), { size: 259 })],
   ]);
 }
 

--- a/clients/rust/vault_client/src/generated/accounts/vault.rs
+++ b/clients/rust/vault_client/src/generated/accounts/vault.rs
@@ -99,11 +99,13 @@ pub struct Vault {
     pub last_full_state_update_slot: u64,
     pub deposit_fee_bps: u16,
     pub withdrawal_fee_bps: u16,
+    pub next_withdrawal_fee_bps: u16,
     pub reward_fee_bps: u16,
+    pub program_fee_bps: u16,
     pub bump: u8,
     pub is_paused: bool,
     #[cfg_attr(feature = "serde", serde(with = "serde_with::As::<serde_with::Bytes>"))]
-    pub reserved: [u8; 263],
+    pub reserved: [u8; 259],
 }
 
 impl Vault {

--- a/idl/jito_vault.json
+++ b/idl/jito_vault.json
@@ -1566,7 +1566,19 @@
             }
           },
           {
+            "name": "nextWithdrawalFeeBps",
+            "type": {
+              "defined": "PodU16"
+            }
+          },
+          {
             "name": "rewardFeeBps",
+            "type": {
+              "defined": "PodU16"
+            }
+          },
+          {
+            "name": "programFeeBps",
             "type": {
               "defined": "PodU16"
             }
@@ -1586,7 +1598,7 @@
             "type": {
               "array": [
                 "u8",
-                263
+                259
               ]
             }
           }

--- a/integration_tests/tests/vault/initialize_vault_update_state_tracker.rs
+++ b/integration_tests/tests/vault/initialize_vault_update_state_tracker.rs
@@ -3,9 +3,12 @@ mod tests {
     use jito_vault_core::{config::Config, vault_update_state_tracker::VaultUpdateStateTracker};
     use jito_vault_sdk::error::VaultError;
     use solana_program::instruction::InstructionError;
+    use solana_sdk::{signature::Keypair, signer::Signer};
 
     use crate::fixtures::{
-        assert_ix_error, fixture::TestBuilder, vault_client::assert_vault_error,
+        assert_ix_error,
+        fixture::{ConfiguredVault, TestBuilder},
+        vault_client::assert_vault_error,
     };
 
     #[tokio::test]
@@ -237,5 +240,313 @@ mod tests {
             .await;
 
         assert_vault_error(test_error, VaultError::VaultIsPaused);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_vault_update_state_tracker_fees_updated() {
+        // Fees are updated if the vault update state tracker is fully updated
+        let mut fixture = TestBuilder::new().await;
+        let mut vault_program_client = fixture.vault_program_client();
+        let (vault_config_admin, vault_root) = vault_program_client
+            .setup_config_and_vault(0, 0, 0)
+            .await
+            .unwrap();
+        let config_pubkey = Config::find_program_address(&jito_vault_program::id()).0;
+        let vault_config = vault_program_client
+            .get_config(&config_pubkey)
+            .await
+            .unwrap();
+
+        let mut restaking_program_client = fixture.restaking_program_client();
+        restaking_program_client
+            .do_initialize_config()
+            .await
+            .unwrap();
+
+        // create ncn operator state + warmup the ncn <> operator relationship
+        let operator_root = restaking_program_client
+            .do_initialize_operator()
+            .await
+            .unwrap();
+        restaking_program_client
+            .do_initialize_operator_vault_ticket(&operator_root, &vault_root.vault_pubkey)
+            .await
+            .unwrap();
+        vault_program_client
+            .do_initialize_vault_operator_delegation(&vault_root, &operator_root.operator_pubkey)
+            .await
+            .unwrap();
+
+        // Check initial fees are 0
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+        assert_eq!(vault.withdrawal_fee_bps(), 0);
+        assert_eq!(vault.next_withdrawal_fee_bps(), 0);
+        assert_eq!(vault.program_fee_bps(), 0);
+
+        fixture
+            .warp_slot_incremental(2 * vault_config.epoch_length())
+            .await
+            .unwrap();
+
+        // Set fees
+        let new_withdrawal_fee_bps = 10;
+        let new_program_fee_bps = 11;
+
+        vault_program_client
+            .set_fees(
+                &config_pubkey,
+                &vault_root.vault_pubkey,
+                &vault_root.vault_admin,
+                None,
+                Some(new_withdrawal_fee_bps),
+                None,
+            )
+            .await
+            .unwrap();
+
+        vault_program_client
+            .set_program_fee(&vault_config_admin, new_program_fee_bps)
+            .await
+            .unwrap();
+
+        // Vault fees not updated yet
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+        assert_eq!(vault.withdrawal_fee_bps(), 0);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.program_fee_bps(), 0);
+
+        fixture
+            .warp_slot_incremental(1 * vault_config.epoch_length())
+            .await
+            .unwrap();
+
+        let slot = fixture.get_current_slot().await.unwrap();
+        vault_program_client
+            .initialize_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                &VaultUpdateStateTracker::find_program_address(
+                    &jito_vault_program::id(),
+                    &vault_root.vault_pubkey,
+                    slot / vault_config.epoch_length(),
+                )
+                .0,
+            )
+            .await
+            .unwrap();
+
+        let vault_update_state_tracker = vault_program_client
+            .get_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                slot / vault_config.epoch_length(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(vault_update_state_tracker.vault, vault_root.vault_pubkey);
+        assert_eq!(
+            vault_update_state_tracker.ncn_epoch(),
+            slot / vault_config.epoch_length()
+        );
+        assert_eq!(vault_update_state_tracker.last_updated_index(), u64::MAX);
+        assert_eq!(
+            vault_update_state_tracker
+                .delegation_state
+                .total_security()
+                .unwrap(),
+            0
+        );
+        // Check fees are updated
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.program_fee_bps(), new_program_fee_bps);
+    }
+
+    #[tokio::test]
+    async fn test_initialize_vault_update_state_tracker_fees_not_updated() {
+        // Fees are not updated if the vault update state tracker is not fully updated
+        let mut fixture = TestBuilder::new().await;
+
+        let deposit_fee_bps = 0;
+        let withdrawal_fee_bps = 0;
+        let reward_fee_bps = 0;
+        let num_operators = 1;
+        let slasher_amounts = vec![];
+
+        let ConfiguredVault {
+            mut vault_program_client,
+            vault_root,
+            operator_roots,
+            vault_config_admin,
+            ..
+        } = fixture
+            .setup_vault_with_ncn_and_operators(
+                deposit_fee_bps,
+                withdrawal_fee_bps,
+                reward_fee_bps,
+                num_operators,
+                &slasher_amounts,
+            )
+            .await
+            .unwrap();
+
+        let depositor = Keypair::new();
+        vault_program_client
+            .configure_depositor(&vault_root, &depositor.pubkey(), 100_000)
+            .await
+            .unwrap();
+        vault_program_client
+            .do_mint_to(&vault_root, &depositor, 100_000, 100_000)
+            .await
+            .unwrap();
+
+        vault_program_client
+            .do_add_delegation(&vault_root, &operator_roots[0].operator_pubkey, 100_000)
+            .await
+            .unwrap();
+
+        vault_program_client
+            .do_enqueue_withdrawal(&vault_root, &depositor, 75_000)
+            .await
+            .unwrap();
+
+        let config_address = Config::find_program_address(&jito_vault_program::id()).0;
+        let config = vault_program_client
+            .get_config(&config_address)
+            .await
+            .unwrap();
+
+        fixture
+            .warp_slot_incremental(2 * config.epoch_length())
+            .await
+            .unwrap();
+
+        // enqueued for cool down assets are now cooling down
+
+        let slot = fixture.get_current_slot().await.unwrap();
+        let ncn_epoch = slot / config.epoch_length();
+
+        let vault_update_state_tracker_pubkey = VaultUpdateStateTracker::find_program_address(
+            &jito_vault_program::id(),
+            &vault_root.vault_pubkey,
+            ncn_epoch,
+        )
+        .0;
+        vault_program_client
+            .initialize_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                &vault_update_state_tracker_pubkey,
+            )
+            .await
+            .unwrap();
+
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+
+        assert_eq!(vault.additional_assets_need_unstaking(), 75_000);
+
+        // Update fees
+        let new_withdrawal_fee_bps = 10;
+        let new_program_fee_bps = 11;
+        vault_program_client
+            .set_fees(
+                &config_address,
+                &vault_root.vault_pubkey,
+                &vault_root.vault_admin,
+                None,
+                Some(new_withdrawal_fee_bps),
+                None,
+            )
+            .await
+            .unwrap();
+        vault_program_client
+            .set_program_fee(&vault_config_admin, new_program_fee_bps)
+            .await
+            .unwrap();
+
+        // skip cranking operator 0, advance to next epoch
+
+        fixture
+            .warp_slot_incremental(config.epoch_length())
+            .await
+            .unwrap();
+
+        let slot = fixture.get_current_slot().await.unwrap();
+        let ncn_epoch = slot / config.epoch_length();
+        // no assets cooled down, additional_assets_need_unstaking = 75_000
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+
+        // no assets cooled down, additional_assets_need_unstaking = 75_000
+        assert_eq!(vault.additional_assets_need_unstaking(), 75_000);
+
+        let vault_update_state_tracker_pubkey = VaultUpdateStateTracker::find_program_address(
+            &jito_vault_program::id(),
+            &vault_root.vault_pubkey,
+            ncn_epoch,
+        )
+        .0;
+        vault_program_client
+            .initialize_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                &vault_update_state_tracker_pubkey,
+            )
+            .await
+            .unwrap();
+
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+
+        // Check fees not updated because of partial update
+        assert_eq!(vault.withdrawal_fee_bps(), 0);
+        assert_eq!(vault.program_fee_bps(), 0);
+
+        vault_program_client
+            .do_crank_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                &operator_roots[0].operator_pubkey,
+            )
+            .await
+            .unwrap();
+
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+
+        // Assets now cooled down
+        assert_eq!(vault.additional_assets_need_unstaking(), 0);
+
+        vault_program_client
+            .close_vault_update_state_tracker(
+                &vault_root.vault_pubkey,
+                &vault_update_state_tracker_pubkey,
+                ncn_epoch,
+            )
+            .await
+            .unwrap();
+
+        let vault = vault_program_client
+            .get_vault(&vault_root.vault_pubkey)
+            .await
+            .unwrap();
+
+        assert_eq!(vault.delegation_state.staked_amount(), 25_000);
+        assert_eq!(vault.delegation_state.enqueued_for_cooldown_amount(), 0);
+        assert_eq!(vault.vrt_ready_to_claim_amount(), 75_000);
     }
 }

--- a/integration_tests/tests/vault/set_fees.rs
+++ b/integration_tests/tests/vault/set_fees.rs
@@ -141,7 +141,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(vault.reward_fee_bps(), new_reward_fee_bps);
     }
 
@@ -233,7 +234,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(vault.reward_fee_bps(), new_reward_fee_bps);
 
         // Warp again
@@ -266,7 +268,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(vault.reward_fee_bps(), new_reward_fee_bps);
     }
 
@@ -371,7 +374,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(vault.reward_fee_bps(), new_reward_fee_bps);
     }
 
@@ -551,7 +555,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
         assert_eq!(vault.reward_fee_bps(), new_reward_fee_bps);
     }
 
@@ -661,7 +666,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(vault.next_withdrawal_fee_bps(), new_withdrawal_fee_bps);
     }
 
     #[tokio::test]
@@ -776,7 +782,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(
+            updated_vault.next_withdrawal_fee_bps(),
+            new_withdrawal_fee_bps
+        );
     }
 
     #[tokio::test]
@@ -829,7 +839,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(
+            updated_vault.next_withdrawal_fee_bps(),
+            new_withdrawal_fee_bps
+        );
         assert_eq!(updated_vault.reward_fee_bps(), reward_fee_bps);
     }
 
@@ -883,6 +897,7 @@ mod tests {
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
         assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(updated_vault.next_withdrawal_fee_bps(), withdrawal_fee_bps);
         assert_eq!(updated_vault.reward_fee_bps(), reward_fee_bps);
 
         let new_withdrawal_fee_bps = withdrawal_fee_bps + 1;
@@ -911,7 +926,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(
+            updated_vault.next_withdrawal_fee_bps(),
+            new_withdrawal_fee_bps
+        );
         assert_eq!(updated_vault.reward_fee_bps(), reward_fee_bps);
 
         let new_reward_fee_bps = reward_fee_bps + 1;
@@ -940,7 +959,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(updated_vault.deposit_fee_bps(), new_deposit_fee_bps);
-        assert_eq!(updated_vault.withdrawal_fee_bps(), new_withdrawal_fee_bps);
+        assert_eq!(updated_vault.withdrawal_fee_bps(), withdrawal_fee_bps);
+        assert_eq!(
+            updated_vault.next_withdrawal_fee_bps(),
+            new_withdrawal_fee_bps
+        );
         assert_eq!(updated_vault.reward_fee_bps(), new_reward_fee_bps);
     }
 

--- a/vault_program/src/add_delegation.rs
+++ b/vault_program/src/add_delegation.rs
@@ -59,7 +59,7 @@ pub fn process_add_delegation(
 
     vault.check_is_paused()?;
 
-    vault.delegate(amount, config.program_fee_bps())?;
+    vault.delegate(amount)?;
 
     vault_operator_delegation
         .delegation_state

--- a/vault_program/src/burn_withdrawal_ticket.rs
+++ b/vault_program/src/burn_withdrawal_ticket.rs
@@ -91,10 +91,7 @@ pub fn process_burn_withdrawal_ticket(
         program_fee_amount,
         burn_amount,
         out_amount,
-    } = vault.burn_with_fee(
-        config.program_fee_bps(),
-        vault_staker_withdrawal_ticket.vrt_amount(),
-    )?;
+    } = vault.burn_with_fee(vault_staker_withdrawal_ticket.vrt_amount())?;
 
     // To close the token account, the balance needs to be 0.
     // The only way for vault_staker_withdrawal_ticket.vrt_amount() != ticket_vrt_amount

--- a/vault_program/src/initialize_vault.rs
+++ b/vault_program/src/initialize_vault.rs
@@ -120,6 +120,7 @@ pub fn process_initialize_vault(
             deposit_fee_bps,
             withdrawal_fee_bps,
             reward_fee_bps,
+            config.program_fee_bps(),
             vault_bump,
             slot,
         )?;

--- a/vault_program/src/initialize_vault_update_state_tracker.rs
+++ b/vault_program/src/initialize_vault_update_state_tracker.rs
@@ -82,12 +82,17 @@ pub fn process_initialize_vault_update_state_tracker(
         // between epochs and we can effectively carry on where we left off
         vault.additional_assets_need_unstaking()
     } else {
+        // Update fees to new values
+        // Fees can only be updated here so `additional_assets_need_unstaking` will be static
+        // Otherwise there may be a mismatch between withdrawn assets and outstanding claim tickets
+        vault.set_withdrawal_fee_bps(vault.next_withdrawal_fee_bps());
+        vault.set_program_fee_bps(config.program_fee_bps());
+
         // If the vault is not in the middle of unstaking, calculate the additional assets needed
         // to unstake
         vault.calculate_additional_supported_assets_needed_to_unstake(
             Clock::get()?.slot,
             config.epoch_length(),
-            config.program_fee_bps(),
         )?
     };
 

--- a/vault_program/src/set_fees.rs
+++ b/vault_program/src/set_fees.rs
@@ -51,7 +51,7 @@ pub fn process_set_fees(
     }
 
     if let Some(withdrawal_fee_bps) = withdrawal_fee_bps {
-        vault.set_withdrawal_fee_bps(
+        vault.set_next_withdrawal_fee_bps(
             withdrawal_fee_bps,
             config.deposit_withdrawal_fee_cap_bps(),
             config.fee_bump_bps(),


### PR DESCRIPTION
An issue was detected in which fees could change after calculating `additional_assets_need_unstaking`, resulting in a mismatch in outstanding funds that can be claimed and the amount actually undelegated from operators. E.g. if fees (program_fee or withdrawal_fee) are lowered after an epoch update, and all withdrawal tickets were claimed, there would be more ST returned  during withdrawals actually was unstaked from operators. 

This is solved by:
* Move program fee to vault (copied each epoch during vault update) so program fee can't arbitrarily change during an epoch
* Add `next_withdrawal_fee_bps` to vault which will store the vault_admin's intended fee for next epoch, so we're not changing the current epoch's fee in `set_fees`
* Only update vault fees when we are starting a new vault update, so that we will have a fixed `additional_assets_need_unstaking` value until the next vault update

