### PR TITLE
Test: add new variable to `no_padding` test

### DIFF
--- a/restaking_core/src/operator.rs
+++ b/restaking_core/src/operator.rs
@@ -267,7 +267,7 @@ impl Operator {
 
 #[cfg(test)]
 mod tests {
-    use jito_bytemuck::types::PodU64;
+    use jito_bytemuck::types::{PodU16, PodU64};
     use solana_program::pubkey::Pubkey;
 
     use crate::operator::Operator;
@@ -285,8 +285,9 @@ mod tests {
             std::mem::size_of::<PodU64>() + // index
             std::mem::size_of::<PodU64>() + // ncn_count
             std::mem::size_of::<PodU64>() + // vault_count
+            std::mem::size_of::<PodU16>() + // operator_fee_bps
             std::mem::size_of::<u8>() + // bump
-            263; // reserved_space
+            261; // reserved_space
         assert_eq!(operator_size, sum_of_fields);
     }
 

--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -1322,11 +1322,12 @@ mod tests {
             std::mem::size_of::<PodU64>() + // last_full_state_update_slot
             std::mem::size_of::<PodU16>() + // deposit_fee_bps
             std::mem::size_of::<PodU16>() + // withdrawal_fee_bps
+            std::mem::size_of::<PodU16>() + // next_withdrawal_fee_bps
             std::mem::size_of::<PodU16>() + // reward_fee_bps
             std::mem::size_of::<PodU16>() + // program_fee_bps
             std::mem::size_of::<PodBool>() + // is_paused
             1 + // bump
-            261; // reserved
+            259; // reserved
 
         assert_eq!(vault_size, sum_of_fields);
     }


### PR DESCRIPTION
I found that some `no_padding` test has not added new variables.