### PR TITLE
Test: change_withdrawal_ticket_owner instruction

### DIFF
--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -946,6 +946,31 @@ impl VaultProgramClient {
         })
     }
 
+    pub async fn change_withdrawal_ticket_owner(
+        &mut self,
+        config: &Pubkey,
+        vault: &Pubkey,
+        vault_staker_withdrawal_ticket: &Pubkey,
+        old_owner: &Keypair,
+        new_owner: &Pubkey,
+    ) -> Result<(), TestError> {
+        let blockhash = self.banks_client.get_latest_blockhash().await?;
+        self._process_transaction(&Transaction::new_signed_with_payer(
+            &[jito_vault_sdk::sdk::change_withdrawal_ticket_owner(
+                &jito_vault_program::id(),
+                config,
+                vault,
+                vault_staker_withdrawal_ticket,
+                &old_owner.pubkey(),
+                new_owner,
+            )],
+            Some(&self.payer.pubkey()),
+            &[&self.payer,old_owner],
+            blockhash
+        ))
+        .await
+    }
+
     pub async fn do_cooldown_delegation(
         &mut self,
         vault_root: &VaultRoot,

--- a/integration_tests/tests/fixtures/vault_client.rs
+++ b/integration_tests/tests/fixtures/vault_client.rs
@@ -946,7 +946,7 @@ impl VaultProgramClient {
         })
     }
 
-    pub async fn change_withdrawal_ticket_owner(
+    pub async fn do_change_withdrawal_ticket_owner(
         &mut self,
         config: &Pubkey,
         vault: &Pubkey,

--- a/vault_sdk/src/sdk.rs
+++ b/vault_sdk/src/sdk.rs
@@ -565,6 +565,29 @@ pub fn enqueue_withdrawal(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub fn change_withdrawal_ticket_owner(
+    program_id: &Pubkey,
+    config: &Pubkey,
+    vault: &Pubkey,
+    vault_staker_withdrawal_ticket: &Pubkey,
+    old_owner: &Pubkey,
+    new_owner: &Pubkey
+) -> Instruction {
+    let accounts = vec![
+        AccountMeta::new_readonly(*config, false),
+        AccountMeta::new(*vault, false),
+        AccountMeta::new(*vault_staker_withdrawal_ticket, false),
+        AccountMeta::new_readonly(*old_owner, true),
+        AccountMeta::new_readonly(*new_owner, false),
+    ];
+    Instruction {
+        program_id: *program_id,
+        accounts,
+        data: VaultInstruction::ChangeWithdrawalTicketOwner.try_to_vec().unwrap(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn burn_withdrawal_ticket(
     program_id: &Pubkey,
     config: &Pubkey,

--- a/vault_sdk/src/sdk.rs
+++ b/vault_sdk/src/sdk.rs
@@ -565,29 +565,6 @@ pub fn enqueue_withdrawal(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn change_withdrawal_ticket_owner(
-    program_id: &Pubkey,
-    config: &Pubkey,
-    vault: &Pubkey,
-    vault_staker_withdrawal_ticket: &Pubkey,
-    old_owner: &Pubkey,
-    new_owner: &Pubkey
-) -> Instruction {
-    let accounts = vec![
-        AccountMeta::new_readonly(*config, false),
-        AccountMeta::new(*vault, false),
-        AccountMeta::new(*vault_staker_withdrawal_ticket, false),
-        AccountMeta::new_readonly(*old_owner, true),
-        AccountMeta::new_readonly(*new_owner, false),
-    ];
-    Instruction {
-        program_id: *program_id,
-        accounts,
-        data: VaultInstruction::ChangeWithdrawalTicketOwner.try_to_vec().unwrap(),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
 pub fn burn_withdrawal_ticket(
     program_id: &Pubkey,
     config: &Pubkey,


### PR DESCRIPTION
Missing `change_withdrawal_ticket_owner` in sdk.rs and vault_client.rs to run integration tests