### PR TITLE
AUDIT: 36903

### DIFF
--- a/vault_core/src/vault.rs
+++ b/vault_core/src/vault.rs
@@ -1007,8 +1007,14 @@ impl Vault {
         })
     }
 
-    pub fn calculate_burn_summary(&self, amount_in: u64) -> Result<BurnSummary, VaultError> {
-        let program_fee_amount = Config::calculate_program_fee(self.program_fee_bps(), amount_in)?;
+    pub fn calculate_burn_summary(
+        &self,
+        is_staker_program_fee_wallet: bool,
+        is_staker_vault_fee_wallet: bool,
+        amount_in: u64,
+    ) -> Result<BurnSummary, VaultError> {
+        let mut program_fee_amount =
+            Config::calculate_program_fee(self.program_fee_bps(), amount_in)?;
         let mut vault_fee_amount = self.calculate_withdrawal_fee(amount_in)?;
 
         // Prioritize program fee over vault fee if together they exceed the amount in
@@ -1020,6 +1026,14 @@ impl Vault {
             vault_fee_amount = amount_in
                 .checked_sub(program_fee_amount)
                 .ok_or(VaultError::VaultUnderflow)?;
+        }
+
+        if is_staker_program_fee_wallet {
+            program_fee_amount = 0;
+        }
+
+        if is_staker_vault_fee_wallet {
+            vault_fee_amount = 0;
         }
 
         let amount_to_burn = amount_in
@@ -1041,7 +1055,12 @@ impl Vault {
         })
     }
 
-    pub fn burn_with_fee(&mut self, amount_in: u64) -> Result<BurnSummary, VaultError> {
+    pub fn burn_with_fee(
+        &mut self,
+        is_staker_program_fee_wallet: bool,
+        is_staker_vault_fee_wallet: bool,
+        amount_in: u64,
+    ) -> Result<BurnSummary, VaultError> {
         if amount_in == 0 {
             msg!("Amount in is zero");
             return Err(VaultError::VaultBurnZero);
@@ -1054,7 +1073,11 @@ impl Vault {
             vault_fee_amount,
             burn_amount,
             out_amount,
-        } = self.calculate_burn_summary(amount_in)?;
+        } = self.calculate_burn_summary(
+            is_staker_program_fee_wallet,
+            is_staker_vault_fee_wallet,
+            amount_in,
+        )?;
 
         let max_withdrawable = self
             .tokens_deposited()
@@ -1102,7 +1125,7 @@ impl Vault {
         let BurnSummary {
             out_amount: amount_to_reserve_for_vrts,
             ..
-        } = self.calculate_burn_summary(vrt_reserve)?;
+        } = self.calculate_burn_summary(false, false, vrt_reserve)?;
 
         Ok(amount_to_reserve_for_vrts)
     }
@@ -1594,10 +1617,58 @@ mod tests {
             program_fee_amount: _,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(100).unwrap();
+        } = vault.burn_with_fee(false, false, 100).unwrap();
         assert_eq!(fee_amount, 1);
         assert_eq!(burn_amount, 99);
         assert_eq!(out_amount, 99);
+    }
+
+    #[test]
+    fn test_burn_with_staker_as_program_fee_wallet() {
+        let mut vault = make_test_vault(0, 100, 100, 100, 100, DelegationState::default());
+
+        let BurnSummary {
+            vault_fee_amount: fee_amount,
+            program_fee_amount,
+            burn_amount,
+            out_amount,
+        } = vault.burn_with_fee(true, false, 100).unwrap();
+        assert_eq!(fee_amount, 1);
+        assert_eq!(program_fee_amount, 0);
+        assert_eq!(burn_amount, 99);
+        assert_eq!(out_amount, 99);
+    }
+
+    #[test]
+    fn test_burn_with_staker_as_vault_fee_wallet() {
+        let mut vault = make_test_vault(0, 100, 100, 100, 100, DelegationState::default());
+
+        let BurnSummary {
+            vault_fee_amount,
+            program_fee_amount,
+            burn_amount,
+            out_amount,
+        } = vault.burn_with_fee(false, true, 100).unwrap();
+        assert_eq!(vault_fee_amount, 0);
+        assert_eq!(program_fee_amount, 1);
+        assert_eq!(burn_amount, 99);
+        assert_eq!(out_amount, 99);
+    }
+
+    #[test]
+    fn test_burn_with_staker_as_both_program_and_vault_fee_wallet() {
+        let mut vault = make_test_vault(0, 100, 100, 100, 100, DelegationState::default());
+
+        let BurnSummary {
+            vault_fee_amount,
+            program_fee_amount,
+            burn_amount,
+            out_amount,
+        } = vault.burn_with_fee(true, true, 100).unwrap();
+        assert_eq!(vault_fee_amount, 0);
+        assert_eq!(program_fee_amount, 0);
+        assert_eq!(burn_amount, 100);
+        assert_eq!(out_amount, 100);
     }
 
     #[test]
@@ -1609,7 +1680,7 @@ mod tests {
             program_fee_amount,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(100).unwrap();
+        } = vault.burn_with_fee(false, false, 100).unwrap();
         assert_eq!(vault_fee_amount, 1);
         assert_eq!(program_fee_amount, 2);
         assert_eq!(burn_amount, 97);
@@ -1625,7 +1696,7 @@ mod tests {
             program_fee_amount,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(100).unwrap();
+        } = vault.burn_with_fee(false, false, 100).unwrap();
         assert_eq!(program_fee_amount, 90);
         assert_eq!(vault_fee_amount, 10);
         assert_eq!(burn_amount, 0);
@@ -1641,7 +1712,7 @@ mod tests {
             program_fee_amount,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(100).unwrap();
+        } = vault.burn_with_fee(false, false, 100).unwrap();
         assert_eq!(vault_fee_amount, 0);
         assert_eq!(program_fee_amount, 100);
         assert_eq!(burn_amount, 0);
@@ -1653,7 +1724,7 @@ mod tests {
         let mut vault = make_test_vault(0, 100, 0, 100, 100, DelegationState::default());
 
         assert_eq!(
-            vault.burn_with_fee(101),
+            vault.burn_with_fee(false, false, 101),
             Err(VaultError::VaultInsufficientFunds)
         );
     }
@@ -1661,7 +1732,10 @@ mod tests {
     #[test]
     fn test_burn_zero_fails() {
         let mut vault = make_test_vault(0, 100, 0, 100, 100, DelegationState::default());
-        assert_eq!(vault.burn_with_fee(0), Err(VaultError::VaultBurnZero));
+        assert_eq!(
+            vault.burn_with_fee(false, false, 0),
+            Err(VaultError::VaultBurnZero)
+        );
     }
 
     #[test]
@@ -1673,7 +1747,7 @@ mod tests {
             program_fee_amount: _,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(50).unwrap();
+        } = vault.burn_with_fee(false, false, 50).unwrap();
         assert_eq!(fee_amount, 0);
         assert_eq!(burn_amount, 50);
         assert_eq!(out_amount, 50);
@@ -1685,14 +1759,17 @@ mod tests {
     fn test_burn_more_than_withdrawable_fails() {
         let mut vault = make_test_vault(0, 0, 0, 100, 100, DelegationState::new(50, 0, 0));
 
-        assert_eq!(vault.burn_with_fee(51), Err(VaultError::VaultUnderflow));
+        assert_eq!(
+            vault.burn_with_fee(false, false, 51),
+            Err(VaultError::VaultUnderflow)
+        );
     }
 
     #[test]
     fn test_burn_all_delegated() {
         let mut vault = make_test_vault(0, 0, 0, 100, 100, DelegationState::new(100, 0, 0));
 
-        let result = vault.burn_with_fee(1);
+        let result = vault.burn_with_fee(false, false, 1);
         assert_eq!(result, Err(VaultError::VaultUnderflow));
     }
 
@@ -1700,7 +1777,7 @@ mod tests {
     fn test_burn_rounding_issues() {
         let mut vault = make_test_vault(0, 0, 0, 1_000_000, 1_000_000, DelegationState::default());
 
-        let result = vault.burn_with_fee(1).unwrap();
+        let result = vault.burn_with_fee(false, false, 1).unwrap();
         assert_eq!(result.out_amount, 1);
         assert_eq!(vault.tokens_deposited(), 999_999);
         assert_eq!(vault.vrt_supply(), 999_999);
@@ -1709,7 +1786,7 @@ mod tests {
     #[test]
     fn test_burn_max_values() {
         let mut vault = make_test_vault(0, 100, 0, u64::MAX, u64::MAX, DelegationState::default());
-        let result = vault.burn_with_fee(u64::MAX).unwrap();
+        let result = vault.burn_with_fee(false, false, u64::MAX).unwrap();
         let fee_amount = (((u64::MAX as u128) * 100).div_ceil(10000)) as u64;
         assert_eq!(result.vault_fee_amount, fee_amount);
     }
@@ -1718,7 +1795,7 @@ mod tests {
     fn test_burn_different_fees() {
         let mut vault = make_test_vault(0, 500, 0, 10000, 10000, DelegationState::default());
 
-        let result = vault.burn_with_fee(1000).unwrap();
+        let result = vault.burn_with_fee(false, false, 1000).unwrap();
         assert_eq!(result.vault_fee_amount, 50);
         assert_eq!(result.burn_amount, 950);
         assert_eq!(result.out_amount, 950);
@@ -1804,7 +1881,7 @@ mod tests {
             program_fee_amount: _,
             burn_amount,
             out_amount,
-        } = vault.burn_with_fee(1).unwrap();
+        } = vault.burn_with_fee(false, false, 1).unwrap();
         assert_eq!(fee_amount, 1);
         assert_eq!(burn_amount, 0);
         assert_eq!(out_amount, 0);
@@ -2339,7 +2416,10 @@ mod tests {
     #[test]
     fn test_burn_with_fee_zero_amount() {
         let mut vault = make_test_vault(0, 0, 0, 1000, 1000, DelegationState::default());
-        assert_eq!(vault.burn_with_fee(0), Err(VaultError::VaultBurnZero));
+        assert_eq!(
+            vault.burn_with_fee(false, false, 0),
+            Err(VaultError::VaultBurnZero)
+        );
     }
 
     // ---------- REWARD FEE HELPERS ------------

--- a/vault_program/src/burn_withdrawal_ticket.rs
+++ b/vault_program/src/burn_withdrawal_ticket.rs
@@ -83,12 +83,20 @@ pub fn process_burn_withdrawal_ticket(
         return Err(VaultError::VaultStakerWithdrawalTicketNotWithdrawable.into());
     }
 
+    let is_staker_program_fee_wallet = config.program_fee_wallet.eq(staker.key);
+    let is_staker_vault_fee_wallet = vault.fee_wallet.eq(staker.key);
+    let amount_in = vault_staker_withdrawal_ticket.vrt_amount();
+
     let BurnSummary {
         vault_fee_amount,
         program_fee_amount,
         burn_amount,
         out_amount,
-    } = vault.burn_with_fee(vault_staker_withdrawal_ticket.vrt_amount())?;
+    } = vault.burn_with_fee(
+        is_staker_program_fee_wallet,
+        is_staker_vault_fee_wallet,
+        amount_in,
+    )?;
 
     // To close the token account, the balance needs to be 0.
     // The only way for vault_staker_withdrawal_ticket.vrt_amount() != ticket_vrt_amount

--- a/vault_program/src/mint_to.rs
+++ b/vault_program/src/mint_to.rs
@@ -19,6 +19,8 @@ use solana_program::{
 };
 use spl_token::instruction::{mint_to, transfer};
 
+use crate::update_vault_balance::process_update_vault_balance;
+
 /// Processes the mint instruction: [`crate::VaultInstruction::MintTo`]
 ///
 /// Note: it's strongly encouraged to call [`jito_vault_sdk::instruction::VaultInstruction::UpdateVaultBalance`] before calling this instruction to ensure
@@ -47,6 +49,19 @@ pub fn process_mint(
     else {
         return Err(ProgramError::NotEnoughAccountKeys);
     };
+
+    // Sudo CPI to update the vault balance
+    {
+        let accounts = [
+            config.clone(),
+            vault_info.clone(),
+            vault_token_account.clone(),
+            vrt_mint.clone(),
+            vault_fee_token_account.clone(),
+            token_program.clone(),
+        ];
+        process_update_vault_balance(program_id, &accounts)?;
+    }
 
     Config::load(program_id, config, false)?;
     let config_data = config.data.borrow();

--- a/vault_program/src/update_vault_balance.rs
+++ b/vault_program/src/update_vault_balance.rs
@@ -40,7 +40,7 @@ pub fn process_update_vault_balance(
     // Calculate rewards
     // - We take our fee in st
     // - We add the reward ( total reward - fee in st )
-    // - We virtually call mint_to on the reward fee ob behalf of the vault
+    // - We virtually call mint_to on the reward fee on behalf of the vault
     let new_st_balance = Account::unpack(&vault_token_account.data.borrow())?.amount;
 
     // 1. Calculate reward fee in ST


### PR DESCRIPTION
+ Call `process_update_vault` first thing in the `mint_to` function. This is the least invasive way of solving this issue, at the cost of some double checking of accounts

Entry:
36903 (High) "The vault reward mechanism can be sandwiched by MEV"

UpdateVaultBalance is not strictly required before mint, or other actions involving vault.deposited_tokens, so new depositors can claim an unfairly large portion of rewards. The reports describe a scenario where rewards have been deposited, but the vault balance has not yet been updated. If a new depositor mints tokens before the balance update, they are included in the reward distribution calculation. In this way, they can claim a share of rewards that they did not contribute to.

The following are duplicates of this submission:

37311 "Attackers can steal rewards by depositing, updating vault balance and withdrawing immediately after a large reward is deposited"

27295 "Rewards can be stolen by depositing immediately after reward tokens get sent to vault"

37315 "Theft of Unclaimed Yields Due to Improper Reward Distribution in Vault Program"
