### PR TITLE
CLI: Squads commands for everything

### DIFF
--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -109,9 +109,14 @@ async fn main() -> Result<(), anyhow::Error> {
 
     match args.command.expect("Command not found") {
         ProgramCommand::Restaking { action } => {
-            RestakingCliHandler::new(cli_config, restaking_program_id, vault_program_id)
-                .handle(action)
-                .await?;
+            RestakingCliHandler::new(
+                cli_config,
+                restaking_program_id,
+                vault_program_id,
+                args.print_tx,
+            )
+            .handle(action)
+            .await?;
         }
         ProgramCommand::Vault { action } => {
             VaultCliHandler::new(cli_config, restaking_program_id, vault_program_id)

--- a/cli/src/bin/main.rs
+++ b/cli/src/bin/main.rs
@@ -119,9 +119,14 @@ async fn main() -> Result<(), anyhow::Error> {
             .await?;
         }
         ProgramCommand::Vault { action } => {
-            VaultCliHandler::new(cli_config, restaking_program_id, vault_program_id)
-                .handle(action)
-                .await?;
+            VaultCliHandler::new(
+                cli_config,
+                restaking_program_id,
+                vault_program_id,
+                args.print_tx,
+            )
+            .handle(action)
+            .await?;
         }
     }
 

--- a/cli/src/cli_args.rs
+++ b/cli/src/cli_args.rs
@@ -31,6 +31,14 @@ pub struct Cli {
     #[arg(long, global = true, help = "Verbose mode")]
     pub verbose: bool,
 
+    #[arg(
+        long,
+        global = true,
+        default_value = "false",
+        help = "This will print out the raw TX instead of running it"
+    )]
+    pub print_tx: bool,
+
     #[arg(long, global = true, hide = true)]
     pub markdown_help: bool,
 }

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -6,6 +6,7 @@ use env_logger::{
     Env,
 };
 use log::Record;
+use solana_sdk::{bs58, instruction::Instruction};
 pub fn init_logger() {
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(format_log_message)
@@ -36,4 +37,25 @@ fn colored_level(style: &mut Style, level: log::Level) -> StyledValue<&'static s
         log::Level::Warn => style.set_color(Color::Yellow).value("WARN "),
         log::Level::Error => style.set_color(Color::Red).value("ERROR"),
     }
+}
+
+pub(crate) fn print_base58_tx(ixs: &[Instruction]) {
+    ixs.iter().for_each(|ix| {
+        log::info!("\n------ IX ------\n");
+
+        log::info!("{}\n", ix.program_id);
+
+        ix.accounts.iter().for_each(|account| {
+            let pubkey = format!("{}", account.pubkey);
+            let writable = if account.is_writable { "W" } else { "" };
+            let signer = if account.is_signer { "S" } else { "" };
+
+            log::info!("{:<44} {:>2} {:>1}", pubkey, writable, signer);
+        });
+
+        log::info!("\n");
+
+        let base58_string = bs58::encode(&ix.data).into_string();
+        log::info!("{}\n", base58_string);
+    });
 }

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -43,19 +43,19 @@ pub(crate) fn print_base58_tx(ixs: &[Instruction]) {
     ixs.iter().for_each(|ix| {
         log::info!("\n------ IX ------\n");
 
-        log::info!("{}\n", ix.program_id);
+        println!("{}\n", ix.program_id);
 
         ix.accounts.iter().for_each(|account| {
             let pubkey = format!("{}", account.pubkey);
             let writable = if account.is_writable { "W" } else { "" };
             let signer = if account.is_signer { "S" } else { "" };
 
-            log::info!("{:<44} {:>2} {:>1}", pubkey, writable, signer);
+            println!("{:<44} {:>2} {:>1}", pubkey, writable, signer);
         });
 
-        log::info!("\n");
+        println!("\n");
 
         let base58_string = bs58::encode(&ix.data).into_string();
-        log::info!("{}\n", base58_string);
+        println!("{}\n", base58_string);
     });
 }

--- a/cli/src/restaking_handler.rs
+++ b/cli/src/restaking_handler.rs
@@ -245,7 +245,7 @@ impl RestakingCliHandler {
     ) -> Result<T> {
         let rpc_client = self.get_rpc_client();
 
-        let account = rpc_client.get_account(&account_pubkey).await?;
+        let account = rpc_client.get_account(account_pubkey).await?;
         let account = T::deserialize(&mut account.data.as_slice())?;
 
         Ok(account)
@@ -313,6 +313,13 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Operator>(&operator)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -369,8 +376,15 @@ impl RestakingCliHandler {
                 role, new_admin, operator
             );
 
-            self.process_transaction(&[ix], &keypair.pubkey(), &[&keypair])
+            self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
                 .await?;
+        }
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Operator>(&operator)
+                .await?;
+            info!("{}", account.pretty_display());
         }
 
         Ok(())
@@ -421,7 +435,7 @@ impl RestakingCliHandler {
 
         info!("Setting delegate for mint: {} to {}", token_mint, delegate,);
 
-        self.process_transaction(&ixs, &keypair.pubkey(), &[&keypair])
+        self.process_transaction(&ixs, &keypair.pubkey(), &[keypair])
             .await?;
 
         Ok(())
@@ -508,6 +522,13 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnVaultTicket>(&ncn_vault_ticket)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -539,6 +560,13 @@ impl RestakingCliHandler {
 
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnVaultTicket>(&ncn_vault_ticket)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -605,6 +633,15 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnOperatorState>(
+                    &ncn_operator_state,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -636,6 +673,15 @@ impl RestakingCliHandler {
 
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnOperatorState>(
+                    &ncn_operator_state,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -669,6 +715,15 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnOperatorState>(
+                    &ncn_operator_state,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -700,6 +755,15 @@ impl RestakingCliHandler {
 
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnOperatorState>(
+                    &ncn_operator_state,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -733,6 +797,15 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::NcnOperatorState>(
+                    &ncn_operator_state,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -756,6 +829,13 @@ impl RestakingCliHandler {
 
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Config>(&config_address)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -783,8 +863,15 @@ impl RestakingCliHandler {
 
         info!("Initializing NCN: {:?}", ncn);
 
-        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair, &base])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Ncn>(&ncn)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -812,8 +899,15 @@ impl RestakingCliHandler {
 
         info!("Initializing Operator: {:?}", operator);
 
-        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair, &base])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Operator>(&operator)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -857,6 +951,15 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::OperatorVaultTicket>(
+                    &operator_vault_ticket,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -898,6 +1001,15 @@ impl RestakingCliHandler {
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
 
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::OperatorVaultTicket>(
+                    &operator_vault_ticket,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -938,6 +1050,15 @@ impl RestakingCliHandler {
 
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::OperatorVaultTicket>(
+                    &operator_vault_ticket,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -1032,6 +1153,13 @@ impl RestakingCliHandler {
         );
         self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
             .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_restaking_client::accounts::Config>(&config_address)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }

--- a/cli/src/restaking_handler.rs
+++ b/cli/src/restaking_handler.rs
@@ -24,7 +24,7 @@ use jito_restaking_core::{
 use log::{debug, info};
 use solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig};
 use solana_program::pubkey::Pubkey;
-use solana_rpc_client::{nonblocking::rpc_client::RpcClient, rpc_client::SerializableTransaction};
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::{
     config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
@@ -265,19 +265,8 @@ impl RestakingCliHandler {
             let blockhash = rpc_client.get_latest_blockhash().await?;
             let tx = Transaction::new_signed_with_payer(ixs, Some(payer), keypairs, blockhash);
             let result = rpc_client.send_and_confirm_transaction(&tx).await?;
+
             info!("Transaction confirmed: {:?}", result);
-
-            let statuses = rpc_client
-                .get_signature_statuses(&[*tx.get_signature()])
-                .await?;
-
-            let tx_status = statuses
-                .value
-                .first()
-                .unwrap()
-                .as_ref()
-                .ok_or_else(|| anyhow!("No signature status"))?;
-            info!("Transaction status: {:?}", tx_status);
         }
 
         Ok(())

--- a/cli/src/vault_handler.rs
+++ b/cli/src/vault_handler.rs
@@ -38,6 +38,7 @@ use solana_rpc_client_api::{
     filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
 };
 use solana_sdk::{
+    instruction::Instruction,
     signature::{read_keypair_file, Keypair, Signer},
     transaction::Transaction,
 };
@@ -47,14 +48,23 @@ use spl_associated_token_account::{
 use spl_token::instruction::transfer;
 
 use crate::{
+    log::print_base58_tx,
     vault::{ConfigActions, VaultActions, VaultCommands},
     CliConfig,
 };
 
 pub struct VaultCliHandler {
+    /// The configuration of CLI
     cli_config: CliConfig,
+
+    /// The Pubkey of Jito Restaking Program ID
     restaking_program_id: Pubkey,
+
+    /// The Pubkey of Jito Vault Program ID
     vault_program_id: Pubkey,
+
+    /// This will print out the raw TX instead of running it
+    print_tx: bool,
 }
 
 impl VaultCliHandler {
@@ -62,11 +72,13 @@ impl VaultCliHandler {
         cli_config: CliConfig,
         restaking_program_id: Pubkey,
         vault_program_id: Pubkey,
+        print_tx: bool,
     ) -> Self {
         Self {
             cli_config,
             restaking_program_id,
             vault_program_id,
+            print_tx,
         }
     }
 
@@ -268,6 +280,50 @@ impl VaultCliHandler {
         }
     }
 
+    pub async fn get_account<T: BorshDeserialize + PrettyDisplay>(
+        &self,
+        account_pubkey: &Pubkey,
+    ) -> Result<T> {
+        let rpc_client = self.get_rpc_client();
+
+        let account = rpc_client.get_account(account_pubkey).await?;
+        let account = T::deserialize(&mut account.data.as_slice())?;
+
+        Ok(account)
+    }
+
+    pub async fn process_transaction(
+        &self,
+        ixs: &[Instruction],
+        payer: &Pubkey,
+        keypairs: &[&Keypair],
+    ) -> Result<()> {
+        let rpc_client = self.get_rpc_client();
+
+        if self.print_tx {
+            print_base58_tx(ixs);
+        } else {
+            let blockhash = rpc_client.get_latest_blockhash().await?;
+            let tx = Transaction::new_signed_with_payer(ixs, Some(payer), keypairs, blockhash);
+            let result = rpc_client.send_and_confirm_transaction(&tx).await?;
+            info!("Transaction confirmed: {:?}", result);
+
+            let statuses = rpc_client
+                .get_signature_statuses(&[*tx.get_signature()])
+                .await?;
+
+            let tx_status = statuses
+                .value
+                .first()
+                .unwrap()
+                .as_ref()
+                .ok_or_else(|| anyhow!("No signature status"))?;
+            info!("Transaction status: {:?}", tx_status);
+        }
+
+        Ok(())
+    }
+
     pub async fn initialize_config(
         &self,
         program_fee_bps: u16,
@@ -278,7 +334,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let mut ix_builder = InitializeConfigBuilder::new();
         let config_address = Config::find_program_address(&self.vault_program_id).0;
@@ -288,22 +343,21 @@ impl VaultCliHandler {
             .restaking_program(self.restaking_program_id)
             .program_fee_wallet(program_fee_wallet)
             .program_fee_bps(program_fee_bps);
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
         info!("Initializing vault config parameters: {:?}", ix_builder);
-        info!(
-            "Initializing vault config transaction: {:?}",
-            tx.get_signature()
-        );
-        rpc_client.send_and_confirm_transaction(&tx).await?;
-        info!("Transaction confirmed: {:?}", tx.get_signature());
-        info!("Vault config initialized at address: {}", config_address);
+
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::Config>(&config_address)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 
@@ -324,7 +378,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let base = Keypair::new();
         let vault = Vault::find_program_address(&self.vault_program_id, &base.pubkey()).0;
@@ -368,6 +421,8 @@ impl VaultCliHandler {
             .reward_fee_bps(reward_fee_bps)
             .decimals(decimals)
             .initialize_token_amount(initialize_token_amount);
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
         let admin_st_token_account_ix =
             create_associated_token_account_idempotent(&admin, &admin, &token_mint, &spl_token::ID);
@@ -375,31 +430,18 @@ impl VaultCliHandler {
         let vault_st_token_account_ix =
             create_associated_token_account_idempotent(&admin, &vault, &token_mint, &spl_token::ID);
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[
-                admin_st_token_account_ix,
-                vault_st_token_account_ix,
-                ix_builder.instruction(),
-            ],
-            Some(&keypair.pubkey()),
-            &[keypair, &base, &vrt_mint],
-            blockhash,
-        );
-        info!("Initializing vault transaction: {:?}", tx.get_signature());
-        let result = rpc_client.send_and_confirm_transaction(&tx).await;
+        info!("Initializing Vault at address: {}", vault);
 
-        if result.is_err() {
-            info!("Transaction failed: {:?}", result.err());
-            return Err(anyhow::anyhow!("Transaction failed"));
+        let ixs = [admin_st_token_account_ix, vault_st_token_account_ix, ix];
+        self.process_transaction(&ixs, &keypair.pubkey(), &[keypair, &base, &vrt_mint])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::Vault>(&vault)
+                .await?;
+            info!("{}", account.pretty_display());
         }
-
-        info!("Transaction confirmed: {:?}", tx.get_signature());
-        info!("\nCreated new vault");
-        info!("Vault address: {}", vault);
-        info!("Base address: {}", base.pubkey());
-        info!("VRT mint address: {}", vrt_mint.pubkey());
-        info!("Token mint address: {}", token_mint);
 
         Ok(())
     }
@@ -820,7 +862,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let ncn = Pubkey::from_str(&ncn)?;
@@ -840,24 +881,20 @@ impl VaultCliHandler {
             .ncn_vault_ticket(ncn_vault_ticket)
             .payer(keypair.pubkey())
             .admin(keypair.pubkey());
-
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
         info!("Initialize Vault NCN Ticket");
-        let result = rpc_client.send_and_confirm_transaction(&tx).await;
 
-        if result.is_err() {
-            println!("Transaction failed: {:?}", result.err());
-            return Err(anyhow::anyhow!("Transaction failed"));
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultNcnTicket>(&vault_ncn_ticket)
+                .await?;
+            info!("{}", account.pretty_display());
         }
-
-        info!("Transaction confirmed: {:?}", result.unwrap());
 
         Ok(())
     }
@@ -868,7 +905,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let ncn = Pubkey::from_str(&ncn)?;
@@ -883,18 +919,20 @@ impl VaultCliHandler {
             .ncn(ncn)
             .vault_ncn_ticket(vault_ncn_ticket)
             .admin(keypair.pubkey());
-
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
         info!("Warmup Vault NCN Ticket");
-        let result = rpc_client.send_and_confirm_transaction(&tx).await?;
-        info!("Transaction confirmed: {:?}", result);
+
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultNcnTicket>(&vault_ncn_ticket)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -905,7 +943,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let ncn = Pubkey::from_str(&ncn)?;
@@ -920,18 +957,20 @@ impl VaultCliHandler {
             .ncn(ncn)
             .vault_ncn_ticket(vault_ncn_ticket)
             .admin(keypair.pubkey());
-
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
         info!("Cooldown Vault NCN Ticket");
-        let result = rpc_client.send_and_confirm_transaction(&tx).await?;
-        info!("Transaction confirmed: {:?}", result);
+
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultNcnTicket>(&vault_ncn_ticket)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -946,7 +985,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let operator = Pubkey::from_str(&operator)?;
@@ -974,25 +1012,22 @@ impl VaultCliHandler {
             .vault_operator_delegation(vault_operator_delegation)
             .payer(keypair.pubkey())
             .admin(keypair.pubkey());
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
-        info!(
-            "Initializing vault operator delegation transaction: {:?}",
-            tx.get_signature()
-        );
-        let result = rpc_client.send_and_confirm_transaction(&tx).await;
+        info!("Initializing vault operator delegation",);
 
-        if result.is_err() {
-            return Err(anyhow::anyhow!("Transaction failed: {:?}", result.err()));
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultOperatorDelegation>(
+                    &vault_operator_delegation,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
         }
-
-        info!("Transaction confirmed: {:?}", tx.get_signature());
 
         Ok(())
     }
@@ -1008,7 +1043,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let operator = Pubkey::from_str(&operator)?;
@@ -1028,23 +1062,23 @@ impl VaultCliHandler {
             .vault_operator_delegation(vault_operator_delegation)
             .admin(keypair.pubkey())
             .amount(amount);
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
-        info!("Delegating to operator: {:?}", tx.get_signature());
-        let result = rpc_client.send_and_confirm_transaction(&tx).await;
+        info!("Delegating to operator");
 
-        if result.is_err() {
-            return Err(anyhow::anyhow!("Transaction failed: {:?}", result.err()));
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultOperatorDelegation>(
+                    &vault_operator_delegation,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+            info!("Delegated {} tokens to {}", amount, operator);
         }
-
-        info!("Transaction confirmed: {:?}", tx.get_signature());
-        info!("Delegated {} tokens to {}", amount, operator);
 
         Ok(())
     }
@@ -1060,7 +1094,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let vault = Pubkey::from_str(&vault)?;
         let operator = Pubkey::from_str(&operator)?;
@@ -1080,23 +1113,23 @@ impl VaultCliHandler {
             .vault_operator_delegation(vault_operator_delegation)
             .admin(keypair.pubkey())
             .amount(amount);
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
-        info!("Cooling down delegation: {:?}", tx.get_signature());
-        let result = rpc_client.send_and_confirm_transaction(&tx).await;
+        info!("Cooling down delegation");
 
-        if result.is_err() {
-            return Err(anyhow::anyhow!("Transaction failed: {:?}", result.err()));
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::VaultOperatorDelegation>(
+                    &vault_operator_delegation,
+                )
+                .await?;
+            info!("{}", account.pretty_display());
+            info!("Cooldown {} tokens for {}", amount, operator);
         }
-
-        info!("Transaction confirmed: {:?}", tx.get_signature());
-        info!("Cooldown {} tokens for {}", amount, operator);
 
         Ok(())
     }
@@ -1488,7 +1521,6 @@ impl VaultCliHandler {
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
         let vault_pubkey = Pubkey::from_str(&vault)?;
-        let rpc_client = self.get_rpc_client();
 
         let mut builder = SetDepositCapacityBuilder::new();
         builder
@@ -1496,25 +1528,20 @@ impl VaultCliHandler {
             .vault(vault_pubkey)
             .admin(keypair.pubkey())
             .amount(amount);
-
-        let recent_blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            recent_blockhash,
-        );
+        let mut ix = builder.instruction();
+        ix.program_id = self.vault_program_id;
 
         info!("Vault capacity instruction: {:?}", builder);
-        info!(
-            "Vault capacity transaction signature: {:?}",
-            tx.get_signature()
-        );
-        rpc_client
-            .send_and_confirm_transaction(&tx)
-            .await
-            .map_err(|e| anyhow!(e.to_string()))?;
-        info!("Transaction confirmed: {:?}", tx.get_signature());
+
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::Vault>(&vault_pubkey)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
 
         Ok(())
     }
@@ -1525,7 +1552,6 @@ impl VaultCliHandler {
             .keypair
             .as_ref()
             .ok_or_else(|| anyhow!("Keypair not provided"))?;
-        let rpc_client = self.get_rpc_client();
 
         let config_address = Config::find_program_address(&self.vault_program_id).0;
         let mut ix_builder = SetConfigAdminBuilder::new();
@@ -1533,21 +1559,21 @@ impl VaultCliHandler {
             .config(config_address)
             .old_admin(keypair.pubkey())
             .new_admin(new_admin);
+        let mut ix = ix_builder.instruction();
+        ix.program_id = self.vault_program_id;
 
-        let blockhash = rpc_client.get_latest_blockhash().await?;
-        let tx = Transaction::new_signed_with_payer(
-            &[ix_builder.instruction()],
-            Some(&keypair.pubkey()),
-            &[keypair],
-            blockhash,
-        );
         info!("Setting vault config admin parameters: {:?}", ix_builder);
-        info!(
-            "Setting vault config admin transaction: {:?}",
-            tx.get_signature()
-        );
-        rpc_client.send_and_confirm_transaction(&tx).await?;
-        info!("Transaction confirmed: {:?}", tx.get_signature());
+
+        self.process_transaction(&[ix], &keypair.pubkey(), &[keypair])
+            .await?;
+
+        if !self.print_tx {
+            let account = self
+                .get_account::<jito_vault_client::accounts::Config>(&config_address)
+                .await?;
+            info!("{}", account.pretty_display());
+        }
+
         Ok(())
     }
 }

--- a/cli/src/vault_handler.rs
+++ b/cli/src/vault_handler.rs
@@ -306,19 +306,8 @@ impl VaultCliHandler {
             let blockhash = rpc_client.get_latest_blockhash().await?;
             let tx = Transaction::new_signed_with_payer(ixs, Some(payer), keypairs, blockhash);
             let result = rpc_client.send_and_confirm_transaction(&tx).await?;
+
             info!("Transaction confirmed: {:?}", result);
-
-            let statuses = rpc_client
-                .get_signature_statuses(&[*tx.get_signature()])
-                .await?;
-
-            let tx_status = statuses
-                .value
-                .first()
-                .unwrap()
-                .as_ref()
-                .ok_or_else(|| anyhow!("No signature status"))?;
-            info!("Transaction status: {:?}", tx_status);
         }
 
         Ok(())

--- a/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
@@ -55,7 +55,7 @@ mod tests {
                 cooling_down_amount: 5,
                 reserved: [0; 256],
             },
-            withdrawal_allocation_method: 1,
+            withdrawal_allocation_method: 0,
             reserved: [0; 263],
         };
 

--- a/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
@@ -55,7 +55,7 @@ mod tests {
                 cooling_down_amount: 5,
                 reserved: [0; 256],
             },
-            withdrawal_allocation_method: 6,
+            withdrawal_allocation_method: 1,
             reserved: [0; 263],
         };
 
@@ -82,10 +82,7 @@ mod tests {
                 .cooling_down_amount
                 .to_string()
         ));
-        assert!(output.contains(
-            &vault_update_state_tracker
-                .withdrawal_allocation_method
-                .to_string()
-        ));
+        // withdrawal_allocation_method
+        assert!(output.contains("Greedy"));
     }
 }

--- a/docs/_tools/00_cli.md
+++ b/docs/_tools/00_cli.md
@@ -29,6 +29,9 @@ A CLI for managing restaking and vault operations
 * `--vault-program-id <VAULT_PROGRAM_ID>` — Vault program ID
 * `--keypair <KEYPAIR>` — Keypair
 * `--verbose` — Verbose mode
+* `--print-tx` — This will print out the raw TX instead of running it
+
+  Default value: `false`
 
 
 


### PR DESCRIPTION
- Add `print-tx` flag. if `print-tx` flag is true, do not process tx, instead print out ix and ix data.
- After initialization, modification of account, print out account information in pretty format.