### PR TITLE
CLI: Add missing instructions + Refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ dependencies = [
  "jito-bytemuck",
  "jito-jsm-core",
  "jito-restaking-client",
+ "jito-restaking-client-common",
  "jito-restaking-core",
  "jito-vault-client",
  "jito-vault-core",
@@ -2563,6 +2564,7 @@ dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
  "bytemuck",
+ "jito-restaking-client-common",
  "num-derive",
  "num-traits",
  "serde",
@@ -2570,6 +2572,10 @@ dependencies = [
  "solana-program",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "jito-restaking-client-common"
+version = "0.0.3"
 
 [[package]]
 name = "jito-restaking-core"
@@ -2671,6 +2677,7 @@ dependencies = [
  "anchor-lang",
  "borsh 0.10.4",
  "bytemuck",
+ "jito-restaking-client-common",
  "num-derive",
  "num-traits",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "account_traits_derive",
     "bytemuck",
     "cli",
+    "clients/rust/common",
     "clients/rust/restaking_client",
     "clients/rust/vault_client",
     "core",
@@ -55,6 +56,7 @@ futures = "0.3.31"
 jito-bytemuck = { path = "bytemuck", version = "=0.0.3" }
 jito-account-traits-derive = { path = "account_traits_derive", version = "=0.0.3" }
 jito-jsm-core = { path = "core", version = "=0.0.3" }
+jito-restaking-client-common = { path = "clients/rust/common", version = "=0.0.3" }
 jito-restaking-client = { path = "clients/rust/restaking_client", version = "=0.0.3" }
 jito-restaking-core = { path = "restaking_core", version = "=0.0.3" }
 jito-restaking-program = { path = "restaking_program", version = "=0.0.3" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = { workspace = true }
 jito-bytemuck = { workspace = true }
 jito-jsm-core = { workspace = true }
 jito-restaking-client = { workspace = true }
+jito-restaking-client-common = { workspace = true }
 jito-restaking-core = { workspace = true }
 jito-vault-client = { workspace = true }
 jito-vault-core = { workspace = true }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -26,6 +26,15 @@ pub struct CliConfig {
 pub(crate) trait CliHandler {
     fn cli_config(&self) -> &CliConfig;
 
+    /// Creates a new Solana RPC client using the configuration from the CLI handler.
+    ///
+    /// This method constructs an RPC client with the URL and commitment level specified in the
+    /// CLI configuration. The client can be used to communicate with a Solana node for
+    /// submitting transactions, querying account data, and other RPC operations.
+    ///
+    /// # Returns
+    ///
+    /// * `RpcClient` - A configured Solana RPC client.
     fn get_rpc_client(&self) -> RpcClient {
         RpcClient::new_with_commitment(
             self.cli_config().rpc_url.clone(),
@@ -33,6 +42,28 @@ pub(crate) trait CliHandler {
         )
     }
 
+    /// Creates an RPC program accounts configuration for fetching accounts of type `T` with an optional public key filter.
+    ///
+    /// This method constructs a configuration that can be used with Solana RPC methods to fetch program accounts
+    /// that match specific criteria. It automatically adds filters for the account data size and the discriminator
+    /// of type `T` to ensure only accounts of the expected type are returned.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The account data type that implements the `jito_bytemuck::Discriminator` trait,
+    ///         which provides a unique 8-byte identifier for the account type.
+    ///
+    /// # Parameters
+    ///
+    /// * `&self` - A reference to the implementing struct.
+    /// * `filter_pubkey` - An optional tuple containing:
+    ///   * A reference to a `Pubkey` to filter by (e.g., an owner or authority)
+    ///   * The byte offset within the account data where this public key should be found
+    ///
+    /// # Returns
+    ///
+    /// * `anyhow::Result<RpcProgramAccountsConfig>` - The configured RPC request on success, or an error if
+    ///   the data size calculation overflows.
     fn get_rpc_program_accounts_config<T: jito_bytemuck::Discriminator>(
         &self,
         filter_pubkey: Option<(&Pubkey, usize)>,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,12 @@
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Keypair};
+use anyhow::anyhow;
+use base64::{engine::general_purpose, Engine};
+use solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig};
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::{
+    config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},
+};
+use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey, signature::Keypair};
 
 pub mod cli_args;
 pub mod log;
@@ -13,4 +21,62 @@ pub struct CliConfig {
     pub commitment: CommitmentConfig,
 
     pub keypair: Option<Keypair>,
+}
+
+pub(crate) trait CliHandler {
+    fn cli_config(&self) -> &CliConfig;
+
+    fn get_rpc_client(&self) -> RpcClient {
+        RpcClient::new_with_commitment(
+            self.cli_config().rpc_url.clone(),
+            self.cli_config().commitment,
+        )
+    }
+
+    fn get_rpc_program_accounts_config<T: jito_bytemuck::Discriminator>(
+        &self,
+        filter_pubkey: Option<(&Pubkey, usize)>,
+    ) -> anyhow::Result<RpcProgramAccountsConfig> {
+        let data_size = std::mem::size_of::<T>()
+            .checked_add(8)
+            .ok_or_else(|| anyhow!("Failed to add"))?;
+
+        let encoded_discriminator =
+            general_purpose::STANDARD.encode(vec![T::DISCRIMINATOR, 0, 0, 0, 0, 0, 0, 0]);
+        let discriminator_filter = RpcFilterType::Memcmp(Memcmp::new(
+            0,
+            MemcmpEncodedBytes::Base64(encoded_discriminator),
+        ));
+
+        let mut filters = vec![
+            RpcFilterType::DataSize(data_size as u64),
+            discriminator_filter,
+        ];
+
+        if let Some((pubkey, offset)) = filter_pubkey {
+            let pubkey_filter = RpcFilterType::Memcmp(Memcmp::new(
+                offset,
+                MemcmpEncodedBytes::Base64(general_purpose::STANDARD.encode(pubkey.to_bytes())),
+            ));
+
+            filters.push(pubkey_filter);
+        }
+
+        let config = RpcProgramAccountsConfig {
+            filters: Some(filters),
+            account_config: RpcAccountInfoConfig {
+                encoding: Some(UiAccountEncoding::Base64),
+                data_slice: Some(UiDataSliceConfig {
+                    offset: 0,
+                    length: data_size,
+                }),
+                commitment: None,
+                min_context_slot: None,
+            },
+            with_context: Some(false),
+            sort_results: Some(false),
+        };
+
+        Ok(config)
+    }
 }

--- a/cli/src/restaking.rs
+++ b/cli/src/restaking.rs
@@ -64,6 +64,10 @@ pub enum NcnActions {
     Get { pubkey: String },
     /// List all NCNs
     List,
+    /// List All Ncn Operator State for a NCN
+    ListNcnOperatorState { ncn: Pubkey },
+    /// List All Ncn Vault Ticket for a NCN
+    ListNcnVaultTicket { ncn: Pubkey },
 }
 
 #[derive(Subcommand)]

--- a/cli/src/restaking.rs
+++ b/cli/src/restaking.rs
@@ -116,4 +116,6 @@ pub enum OperatorActions {
     Get { pubkey: String },
     /// List all operators
     List,
+    /// List Operator Vault Ticket for an Operator
+    ListOperatorVaultTicket { operator: Pubkey },
 }

--- a/cli/src/restaking.rs
+++ b/cli/src/restaking.rs
@@ -118,4 +118,6 @@ pub enum OperatorActions {
     List,
     /// List Operator Vault Ticket for an Operator
     ListOperatorVaultTicket { operator: Pubkey },
+    /// List All Ncn Operator State for a Operator
+    ListNcnOperatorState { operator: Pubkey },
 }

--- a/cli/src/vault.rs
+++ b/cli/src/vault.rs
@@ -164,8 +164,6 @@ pub enum VaultActions {
     GetVaultUpdateStateTracker {
         /// Vault account
         vault: String,
-        /// NCN epoch
-        ncn_epoch: u64,
     },
     /// Gets the operator delegation for a vault
     GetOperatorDelegation {

--- a/cli/src/vault.rs
+++ b/cli/src/vault.rs
@@ -165,6 +165,11 @@ pub enum VaultActions {
         /// Vault account
         vault: String,
     },
+    /// Gets the operator delegations for a vault
+    GetOperatorDelegations {
+        /// Vault account
+        vault: String,
+    },
     /// Gets the operator delegation for a vault
     GetOperatorDelegation {
         /// Vault account

--- a/cli/src/vault_handler.rs
+++ b/cli/src/vault_handler.rs
@@ -1519,14 +1519,17 @@ impl VaultCliHandler {
                     .get_program_accounts_with_config(&self.vault_program_id, config)
                     .await?;
 
-                for (_pubkey, account) in accounts {
+                let mut count = 0;
+                for (pubkey, account) in accounts {
                     let vault_operator_delegation =
                         jito_vault_client::accounts::VaultOperatorDelegation::deserialize(
                             &mut account.data.as_slice(),
                         )?;
 
                     if vault_operator_delegation.vault.eq(&vault) {
+                        info!("Vault Operator Delegation {} at address {}", count, pubkey);
                         info!("{}", vault_operator_delegation.pretty_display());
+                        count += 1;
                     }
                 }
             }

--- a/clients/rust/common/Cargo.toml
+++ b/clients/rust/common/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "jito-restaking-client-common"
+description = "Jito Client Common Crate"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+readme = { workspace = true }

--- a/clients/rust/common/src/lib.rs
+++ b/clients/rust/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod log;

--- a/clients/rust/common/src/log.rs
+++ b/clients/rust/common/src/log.rs
@@ -1,0 +1,15 @@
+pub trait PrettyDisplay {
+    fn pretty_display(&self) -> String;
+}
+
+pub fn account_header(title: &str) -> String {
+    format!("\n{}\n", title)
+}
+
+pub fn section_header(title: &str) -> String {
+    format!("\n━━━ {} ━━━\n", title)
+}
+
+pub fn field(name: &str, value: impl std::fmt::Display) -> String {
+    format!("  {}: {}\n", name, value)
+}

--- a/clients/rust/restaking_client/Cargo.toml
+++ b/clients/rust/restaking_client/Cargo.toml
@@ -19,6 +19,7 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = { workspace = true }
 borsh = { workspace = true }
 bytemuck = { workspace = true }
+jito-restaking-client-common = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/clients/rust/restaking_client/src/log/config.rs
+++ b/clients/rust/restaking_client/src/log/config.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::Config;
 
 impl PrettyDisplay for Config {
@@ -28,8 +29,9 @@ impl PrettyDisplay for Config {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::Config, log::PrettyDisplay};
+    use crate::accounts::Config;
 
     #[test]
     fn test_config_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/mod.rs
+++ b/clients/rust/restaking_client/src/log/mod.rs
@@ -5,19 +5,3 @@ pub(crate) mod ncn_vault_slasher_ticket;
 pub(crate) mod ncn_vault_ticket;
 pub(crate) mod operator;
 pub(crate) mod operator_vault_ticket;
-
-pub trait PrettyDisplay {
-    fn pretty_display(&self) -> String;
-}
-
-fn account_header(title: &str) -> String {
-    format!("\n{}\n", title)
-}
-
-fn section_header(title: &str) -> String {
-    format!("\n{}\n", format!("━━━ {} ━━━", title))
-}
-
-fn field(name: &str, value: impl std::fmt::Display) -> String {
-    format!("  {}: {}\n", name, value)
-}

--- a/clients/rust/restaking_client/src/log/ncn.rs
+++ b/clients/rust/restaking_client/src/log/ncn.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::Ncn;
 
 impl PrettyDisplay for Ncn {
@@ -34,8 +35,9 @@ impl PrettyDisplay for Ncn {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::Ncn, log::PrettyDisplay};
+    use crate::accounts::Ncn;
 
     #[test]
     fn test_ncn_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/ncn_operator_state.rs
+++ b/clients/rust/restaking_client/src/log/ncn_operator_state.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::NcnOperatorState;
 
 impl PrettyDisplay for NcnOperatorState {
@@ -37,8 +38,9 @@ impl PrettyDisplay for NcnOperatorState {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::NcnOperatorState, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::NcnOperatorState, types::SlotToggle};
 
     #[test]
     fn test_ncn_operator_state_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/ncn_vault_slasher_ticket.rs
+++ b/clients/rust/restaking_client/src/log/ncn_vault_slasher_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::NcnVaultSlasherTicket;
 
 impl PrettyDisplay for NcnVaultSlasherTicket {
@@ -29,8 +30,9 @@ impl PrettyDisplay for NcnVaultSlasherTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::NcnVaultSlasherTicket, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::NcnVaultSlasherTicket, types::SlotToggle};
 
     #[test]
     fn test_ncn_vault_slasher_ticket_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/ncn_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/log/ncn_vault_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::NcnVaultTicket;
 
 impl PrettyDisplay for NcnVaultTicket {
@@ -24,8 +25,9 @@ impl PrettyDisplay for NcnVaultTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::NcnVaultTicket, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::NcnVaultTicket, types::SlotToggle};
 
     #[test]
     fn test_ncn_vault_ticket_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/operator.rs
+++ b/clients/rust/restaking_client/src/log/operator.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::Operator;
 
 impl PrettyDisplay for Operator {
@@ -32,8 +33,9 @@ impl PrettyDisplay for Operator {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::Operator, log::PrettyDisplay};
+    use crate::accounts::Operator;
 
     #[test]
     fn test_operator_pretty_display_structure() {

--- a/clients/rust/restaking_client/src/log/operator_vault_ticket.rs
+++ b/clients/rust/restaking_client/src/log/operator_vault_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::OperatorVaultTicket;
 
 impl PrettyDisplay for OperatorVaultTicket {
@@ -24,8 +25,9 @@ impl PrettyDisplay for OperatorVaultTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::OperatorVaultTicket, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::OperatorVaultTicket, types::SlotToggle};
 
     #[test]
     fn test_operator_vault_ticket_pretty_display_structure() {

--- a/clients/rust/vault_client/Cargo.toml
+++ b/clients/rust/vault_client/Cargo.toml
@@ -19,6 +19,7 @@ idl-build = ["anchor-lang/idl-build"]
 anchor-lang = { workspace = true }
 borsh = { workspace = true }
 bytemuck = { workspace = true }
+jito-restaking-client-common = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 serde = { workspace = true }

--- a/clients/rust/vault_client/src/log/config.rs
+++ b/clients/rust/vault_client/src/log/config.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::Config;
 
 impl PrettyDisplay for Config {
@@ -39,8 +40,9 @@ impl PrettyDisplay for Config {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::Config, log::PrettyDisplay};
+    use crate::accounts::Config;
 
     #[test]
     fn test_config_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/metadata.rs
+++ b/clients/rust/vault_client/src/log/metadata.rs
@@ -1,7 +1,6 @@
 use anchor_lang::prelude::Pubkey;
 use borsh::BorshDeserialize;
-
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
 
 #[derive(Clone, BorshDeserialize, Debug, PartialEq, Eq)]
 pub struct Metadata {
@@ -41,8 +40,9 @@ impl PrettyDisplay for Metadata {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::log::{metadata::Metadata, PrettyDisplay};
+    use crate::log::metadata::Metadata;
 
     #[test]
     fn test_config_pretty_display_structure() {
@@ -52,7 +52,7 @@ mod tests {
             mint: Pubkey::new_unique(),
             name: String::from("Jito Staked SOL"),
             symbol: String::from("JitoSOL"),
-            uri: String::from("https:://example.com"),
+            uri: String::from("https://example.com"),
             seller_fee_basis_points: 0,
             creators: None,
             primary_sale_happened: false,

--- a/clients/rust/vault_client/src/log/metadata.rs
+++ b/clients/rust/vault_client/src/log/metadata.rs
@@ -1,0 +1,71 @@
+use anchor_lang::prelude::Pubkey;
+use borsh::BorshDeserialize;
+
+use super::{account_header, field, section_header, PrettyDisplay};
+
+#[derive(Clone, BorshDeserialize, Debug, PartialEq, Eq)]
+pub struct Metadata {
+    pub key: u8,
+    pub update_authority: Pubkey,
+    pub mint: Pubkey,
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+    pub seller_fee_basis_points: u16,
+    pub creators: Option<Vec<u8>>,
+    pub primary_sale_happened: bool,
+    pub is_mutable: bool,
+}
+
+impl PrettyDisplay for Metadata {
+    fn pretty_display(&self) -> String {
+        let mut output = String::new();
+
+        output.push_str(&account_header("Token Metadata Account"));
+
+        output.push_str(&section_header("Basic Information"));
+        output.push_str(&field("Update Authority", self.update_authority));
+        output.push_str(&field("Mint", self.mint));
+        output.push_str(&field("Name", &self.name));
+        output.push_str(&field("Symbol", &self.symbol));
+        output.push_str(&field("URI", &self.uri));
+        output.push_str(&field(
+            "Seller Fee Basis Points",
+            self.seller_fee_basis_points,
+        ));
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anchor_lang::prelude::Pubkey;
+
+    use crate::log::{metadata::Metadata, PrettyDisplay};
+
+    #[test]
+    fn test_config_pretty_display_structure() {
+        let metadata = Metadata {
+            key: 0,
+            update_authority: Pubkey::new_unique(),
+            mint: Pubkey::new_unique(),
+            name: String::from("Jito Staked SOL"),
+            symbol: String::from("JitoSOL"),
+            uri: String::from("https:://example.com"),
+            seller_fee_basis_points: 0,
+            creators: None,
+            primary_sale_happened: false,
+            is_mutable: false,
+        };
+
+        let output = metadata.pretty_display();
+
+        assert!(output.contains(&metadata.update_authority.to_string()));
+        assert!(output.contains(&metadata.mint.to_string()));
+        assert!(output.contains(&metadata.name.to_string()));
+        assert!(output.contains(&metadata.symbol.to_string()));
+        assert!(output.contains(&metadata.uri.to_string()));
+        assert!(output.contains(&metadata.seller_fee_basis_points.to_string()));
+    }
+}

--- a/clients/rust/vault_client/src/log/mod.rs
+++ b/clients/rust/vault_client/src/log/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+pub mod metadata;
 pub(crate) mod vault;
 pub(crate) mod vault_ncn_slasher_operator_ticket;
 pub(crate) mod vault_ncn_slasher_ticket;

--- a/clients/rust/vault_client/src/log/mod.rs
+++ b/clients/rust/vault_client/src/log/mod.rs
@@ -7,19 +7,3 @@ pub(crate) mod vault_ncn_ticket;
 pub(crate) mod vault_operator_delegation;
 pub(crate) mod vault_staker_withdrawal_ticket;
 pub(crate) mod vault_update_state_tracker;
-
-pub trait PrettyDisplay {
-    fn pretty_display(&self) -> String;
-}
-
-fn account_header(title: &str) -> String {
-    format!("\n{}\n", title)
-}
-
-fn section_header(title: &str) -> String {
-    format!("\n{}\n", format!("━━━ {} ━━━", title))
-}
-
-fn field(name: &str, value: impl std::fmt::Display) -> String {
-    format!("  {}: {}\n", name, value)
-}

--- a/clients/rust/vault_client/src/log/vault.rs
+++ b/clients/rust/vault_client/src/log/vault.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::Vault;
 
 impl PrettyDisplay for Vault {
@@ -89,8 +90,9 @@ impl PrettyDisplay for Vault {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::Vault, log::PrettyDisplay, types::DelegationState};
+    use crate::{accounts::Vault, types::DelegationState};
 
     #[test]
     fn test_vault_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_ncn_slasher_operator_ticket.rs
+++ b/clients/rust/vault_client/src/log/vault_ncn_slasher_operator_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultNcnSlasherOperatorTicket;
 
 impl PrettyDisplay for VaultNcnSlasherOperatorTicket {
@@ -23,8 +24,9 @@ impl PrettyDisplay for VaultNcnSlasherOperatorTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultNcnSlasherOperatorTicket, log::PrettyDisplay};
+    use crate::accounts::VaultNcnSlasherOperatorTicket;
 
     #[test]
     fn test_vault_ncn_slasher_operator_ticket_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_ncn_slasher_ticket.rs
+++ b/clients/rust/vault_client/src/log/vault_ncn_slasher_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultNcnSlasherTicket;
 
 impl PrettyDisplay for VaultNcnSlasherTicket {
@@ -29,8 +30,9 @@ impl PrettyDisplay for VaultNcnSlasherTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultNcnSlasherTicket, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::VaultNcnSlasherTicket, types::SlotToggle};
 
     #[test]
     fn test_vault_ncn_slasher_ticket_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_ncn_ticket.rs
+++ b/clients/rust/vault_client/src/log/vault_ncn_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultNcnTicket;
 
 impl PrettyDisplay for VaultNcnTicket {
@@ -24,8 +25,9 @@ impl PrettyDisplay for VaultNcnTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultNcnTicket, log::PrettyDisplay, types::SlotToggle};
+    use crate::{accounts::VaultNcnTicket, types::SlotToggle};
 
     #[test]
     fn test_vault_ncn_ticket_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_operator_delegation.rs
+++ b/clients/rust/vault_client/src/log/vault_operator_delegation.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultOperatorDelegation;
 
 impl PrettyDisplay for VaultOperatorDelegation {
@@ -32,8 +33,9 @@ impl PrettyDisplay for VaultOperatorDelegation {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultOperatorDelegation, log::PrettyDisplay, types::DelegationState};
+    use crate::{accounts::VaultOperatorDelegation, types::DelegationState};
 
     #[test]
     fn test_vault_operator_delegation_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_staker_withdrawal_ticket.rs
+++ b/clients/rust/vault_client/src/log/vault_staker_withdrawal_ticket.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultStakerWithdrawalTicket;
 
 impl PrettyDisplay for VaultStakerWithdrawalTicket {
@@ -22,8 +23,9 @@ impl PrettyDisplay for VaultStakerWithdrawalTicket {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultStakerWithdrawalTicket, log::PrettyDisplay};
+    use crate::accounts::VaultStakerWithdrawalTicket;
 
     #[test]
     fn test_vault_staker_withdrawal_ticket_pretty_display_structure() {

--- a/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
+++ b/clients/rust/vault_client/src/log/vault_update_state_tracker.rs
@@ -1,4 +1,5 @@
-use super::{account_header, field, section_header, PrettyDisplay};
+use jito_restaking_client_common::log::{account_header, field, section_header, PrettyDisplay};
+
 use crate::accounts::VaultUpdateStateTracker;
 
 impl PrettyDisplay for VaultUpdateStateTracker {
@@ -39,8 +40,9 @@ impl PrettyDisplay for VaultUpdateStateTracker {
 #[cfg(test)]
 mod tests {
     use anchor_lang::prelude::Pubkey;
+    use jito_restaking_client_common::log::PrettyDisplay;
 
-    use crate::{accounts::VaultUpdateStateTracker, log::PrettyDisplay, types::DelegationState};
+    use crate::{accounts::VaultUpdateStateTracker, types::DelegationState};
 
     #[test]
     fn test_vault_update_state_tracker_pretty_display_structure() {

--- a/docs/_tools/00_cli.md
+++ b/docs/_tools/00_cli.md
@@ -107,6 +107,8 @@ Set the config admin
 * `ncn-delegate-token-account` — NCN Delegate Token Account
 * `get` — Get NCN
 * `list` — List all NCNs
+* `list-ncn-operator-state` — List All Ncn Operator State for a NCN
+* `list-ncn-vault-ticket` — List All Ncn Vault Ticket for a NCN
 
 
 
@@ -238,6 +240,30 @@ List all NCNs
 
 
 
+## `jito-restaking-cli restaking ncn list-ncn-operator-state`
+
+List All Ncn Operator State for a NCN
+
+**Usage:** `jito-restaking-cli restaking ncn list-ncn-operator-state <NCN>`
+
+###### **Arguments:**
+
+* `<NCN>`
+
+
+
+## `jito-restaking-cli restaking ncn list-ncn-vault-ticket`
+
+List All Ncn Vault Ticket for a NCN
+
+**Usage:** `jito-restaking-cli restaking ncn list-ncn-vault-ticket <NCN>`
+
+###### **Arguments:**
+
+* `<NCN>`
+
+
+
 ## `jito-restaking-cli restaking operator`
 
 **Usage:** `jito-restaking-cli restaking operator <COMMAND>`
@@ -255,6 +281,8 @@ List all NCNs
 * `operator-delegate-token-account` — Operator Delegate Token Account
 * `get` — Get operator
 * `list` — List all operators
+* `list-operator-vault-ticket` — List Operator Vault Ticket for an Operator
+* `list-ncn-operator-state` — List All Ncn Operator State for a Operator
 
 
 
@@ -407,6 +435,30 @@ List all operators
 
 
 
+## `jito-restaking-cli restaking operator list-operator-vault-ticket`
+
+List Operator Vault Ticket for an Operator
+
+**Usage:** `jito-restaking-cli restaking operator list-operator-vault-ticket <OPERATOR>`
+
+###### **Arguments:**
+
+* `<OPERATOR>`
+
+
+
+## `jito-restaking-cli restaking operator list-ncn-operator-state`
+
+List All Ncn Operator State for a Operator
+
+**Usage:** `jito-restaking-cli restaking operator list-ncn-operator-state <OPERATOR>`
+
+###### **Arguments:**
+
+* `<OPERATOR>`
+
+
+
 ## `jito-restaking-cli vault`
 
 Vault program commands
@@ -489,6 +541,7 @@ Vault commands
 * `enqueue-withdrawal` — Starts the withdrawal process
 * `burn-withdrawal-ticket` — Burns the withdrawal ticket, ending the withdrawal process
 * `get-vault-update-state-tracker` — Gets the update state tracker for a vault
+* `get-operator-delegations` — Gets the operator delegations for a vault
 * `get-operator-delegation` — Gets the operator delegation for a vault
 * `get-withdrawal-ticket` — 
 * `get` — Gets a vault
@@ -706,12 +759,23 @@ Burns the withdrawal ticket, ending the withdrawal process
 
 Gets the update state tracker for a vault
 
-**Usage:** `jito-restaking-cli vault vault get-vault-update-state-tracker <VAULT> <NCN_EPOCH>`
+**Usage:** `jito-restaking-cli vault vault get-vault-update-state-tracker <VAULT>`
 
 ###### **Arguments:**
 
 * `<VAULT>` — Vault account
-* `<NCN_EPOCH>` — NCN epoch
+
+
+
+## `jito-restaking-cli vault vault get-operator-delegations`
+
+Gets the operator delegations for a vault
+
+**Usage:** `jito-restaking-cli vault vault get-operator-delegations <VAULT>`
+
+###### **Arguments:**
+
+* `<VAULT>` — Vault account
 
 
 


### PR DESCRIPTION
### Restaking

#### Config
- ✅ Get

#### NCN (3uuk8hsYy7hX2p2ghccXvGp5XeTtcEzvkb27dKZAmbxA)
- ✅ Initialize
- ✅ InitializeNcnOperatorState
- ✅ WarmupOperator
- ✅ CooldownOperator
- ✅ InitializeNcnVaultTicket
- ✅ WarmupNcnVaultTicket
- ✅ CoolodownNcnVaultTicket
- ✅  List `ncn-operator-state`
- ✅  List `ncn-vault-ticket`

#### Operator (8bMpe8G7riJzs6UPiKLbBSrWJE3uHkjhCh6dJ9YRGQZq)
- ✅  Initialize
- ✅ InitializeOperatorVaultTicket
- ✅ WarmupOperatorVaultTicket
- ✅ CooldownOperatorVaultTicket
- ✅ OperatorWarmupNcn
- ✅ OperatorCooldownNcn
- ✅ SetSecondaryAdmin
- ✅ SetOperatorFee
- ✅  List `operator-vault-ticket`
- ✅  List `ncn-operator-state`

### Vault 

#### Config
- ✅ Get

#### Vault (EUNrx27wcHSuvd8ATfvBNH3G32Cjizk8AfGRm36qnKTy)
- ✅ Initialize
- ✅ Create Token Metadata
- ✅ Update Token Metadata
- ✅ Initialize Operator Delegation
- ✅ Delegate To Operator
- ✅ Cooldown Operator Delegation
- ✅ Initialize Vault Ncn Ticket
- ✅ Warmup Vault Ncn Ticket
- ✅ Cooldown Vault Ncn Ticket
- ✅  get-vault-update-state-tracker: Remove ncn_epoch, instead use current epoch
- ✅  get-vault: Add VRT metadata
- ✅  list-vault: Add VRT metadata