### PR TITLE
cranker: emit cluster name in metrics

### DIFF
--- a/crankers/src/bin/main.rs
+++ b/crankers/src/bin/main.rs
@@ -152,7 +152,10 @@ async fn main() -> anyhow::Result<(), anyhow::Error> {
         async move {
             let metrics_client = RpcClient::new_with_timeout(args.rpc_url, Duration::from_secs(60));
             loop {
-                if let Err(e) = emit_vault_metrics(&metrics_client, epoch_length).await {
+                if let Err(e) =
+                    emit_vault_metrics(&metrics_client, epoch_length, &args.cluster.to_string())
+                        .await
+                {
                     error!("Failed to emit metrics: {}", e);
                 }
                 tokio::time::sleep(Duration::from_secs(args.metrics_interval)).await;

--- a/crankers/src/metrics.rs
+++ b/crankers/src/metrics.rs
@@ -13,6 +13,7 @@ use crate::vault_handler::VaultHandler;
 pub async fn emit_vault_metrics(
     rpc_client: &RpcClient,
     config_epoch_length: u64,
+    cluster_name: &str,
 ) -> anyhow::Result<()> {
     let slot = rpc_client.get_slot().await?;
     let epoch = slot / config_epoch_length;
@@ -109,6 +110,7 @@ pub async fn emit_vault_metrics(
             ("vrt_supply_external", vrt_mint.supply as i64, i64),
             ("st_supply_internal", vault.tokens_deposited() as i64, i64),
             ("st_supply_external", st_deposit_account.amount as i64, i64),
+            "cluster" => cluster_name,
         );
     }
 
@@ -128,6 +130,7 @@ pub async fn emit_vault_metrics(
             num_vault_operator_delegations_updated,
             i64
         ),
+        "cluster" => cluster_name,
     );
 
     Ok(())


### PR DESCRIPTION
**Problem**
We would like to differentiate between instances of restaking cranker running against different Solana clusters but lack the ability to do so.

**Solution**
- Wire through the `cluster` arg to `datapoint_info!` calls as a tag