### PR TITLE
CLI: Downgrade `solana-*` version temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Jito Restaking is a next-generation restaking platform for Solana and SVM enviro
 
 ## Documentation
 
-The comprehensive documentation for Stakenet has moved to [jito.network/docs/restaking/jito-restaking-overview](https://www.jito.network/docs/restaking/jito-restaking-overview/).
+The comprehensive documentation for Restaking has moved to [jito.network/docs/restaking/jito-restaking-overview](https://www.jito.network/docs/restaking/jito-restaking-overview/).
 The source files are maintained in the [Jito Omnidocs repository](https://github.com/jito-foundation/jito-omnidocs/tree/master/restaking).
 
 ## SDKs

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-readme = { workspace = true }
+readme = "./README.md"
 
 [dependencies]
 anyhow = { workspace = true }
@@ -29,13 +29,13 @@ jito-vault-sdk = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-account-decoder = { workspace = true }
-solana-cli-config = { workspace = true }
-solana-program = { workspace = true }
-solana-remote-wallet = { workspace = true }
-solana-rpc-client = { workspace = true }
-solana-rpc-client-api = { workspace = true }
-solana-sdk = { workspace = true }
+solana-account-decoder = "2.1.21"
+solana-cli-config = "2.1.21"
+solana-program = "2.1.21"
+solana-remote-wallet = "2.1.21"
+solana-rpc-client = "2.1.21"
+solana-rpc-client-api = "2.1.21"
+solana-sdk = "2.1.21"
 spl-associated-token-account = { workspace = true }
 spl-token = { workspace = true }
 thiserror = { workspace = true }

--- a/cli/README.md
+++ b/cli/README.md
@@ -125,7 +125,7 @@ This allows you to keep your private keys secure on your hardware device instead
 You can specify a Ledger device as the signer by using the `usb://ledger?key=0` in any command that accepts keypair arguments.
 
 ```bash
---signer usb://ledger?key=0
+--signer "usb://ledger?key=0"
 ```
 
 When you specify a Ledger path, the CLI will automatically connect to your Ledger device and prompt you to confirm the transaction on the device.
@@ -133,7 +133,7 @@ When you specify a Ledger path, the CLI will automatically connect to your Ledge
 ##### Set Admin
 
 ```bash
-jito-restaking-cli vault vault set-admin --old-admin-keypair <OLD_ADMIN_KEYPAIR> --new-admin-keypair usb://ledger?key=0 <VAULT>
+jito-restaking-cli vault vault set-admin --old-admin-keypair <OLD_ADMIN_KEYPAIR> --new-admin-keypair "usb://ledger?key=0" <VAULT>
 ```
 
 ##### Using Ledger with Other Commands
@@ -141,7 +141,7 @@ jito-restaking-cli vault vault set-admin --old-admin-keypair <OLD_ADMIN_KEYPAIR>
 You can use your Ledger device with any command that accepts a signer argument. The CLI will automatically handle the connection and signing process with your Ledger device.
 
 ```bash
-jito-restaking-cli -- vault vault set-secondary-admin <VAULT> <SECONDARY_ADMIN> --set-metadata-admin --signer 'usb://ledger?key=0'
+jito-restaking-cli -- vault vault set-secondary-admin <VAULT> <SECONDARY_ADMIN> --set-metadata-admin --signer "usb://ledger?key=0"
 ```
 
 ## Getting Started


### PR DESCRIPTION
- Currently, having issue with publishing `jito-restaking-cli` https://github.com/jito-foundation/restaking/actions/runs/16354829600 
- Since jito-* crates v0.0.5 relies on solana-* ~v2.1
- We temporarily downgrade solana-*