### PR TITLE
CI/CD: Add procps 

### DIFF
--- a/crankers/Dockerfile
+++ b/crankers/Dockerfile
@@ -24,6 +24,7 @@ FROM debian:bullseye-slim as cranker
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl1.1 \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/src/app/target/release/jito-vault-crank /usr/local/bin/jito-vault-crank


### PR DESCRIPTION
- To do health check of Jito Vault Cranker on remote machine, we need to install procps library